### PR TITLE
Fix gettings a config loading so that microservice will run sucessful…

### DIFF
--- a/app/uk/gov/hmrc/gform/ApplicationLoader.scala
+++ b/app/uk/gov/hmrc/gform/ApplicationLoader.scala
@@ -103,7 +103,7 @@ class ApplicationModule(context: Context) extends BuiltInComponentsFromContext(c
   override lazy val appNameConfiguration = configuration
   override lazy val mode = environment.mode
 
-  Logger.info(s"Starting microservice : $appName : in mode : ${environment.mode} at port ${application.configuration.getConfig("http.port")}")
+  Logger.info(s"Starting microservice : $appName : in mode : ${environment.mode} at port ${application.configuration.getString("http.port")}")
 
   new Graphite(configuration).onStart(configurationApp)
 


### PR DESCRIPTION
…ly under service manager using fatjars.  Running like that uses a -Dhttp.port=9195,causing the service not to start, because of:

Caused by: com.typesafe.config.ConfigException$WrongType: system properties: http.port has type STRING rather than OBJECT