### PR TITLE
Trim all whitespace from submission XML etc.

### DIFF
--- a/app/uk/gov/hmrc/gform/fileupload/FileUploadService.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/FileUploadService.scala
@@ -46,7 +46,7 @@ class FileUploadService(fileUploadConnector: FileUploadConnector, fileUploadFron
     val uploadPfdF: Future[Unit] = fileUploadFrontendConnector.upload(
       envelopeId,
       pdf,
-      s"$fileNamePrefix-form.pdf",
+      s"$fileNamePrefix-iform.pdf",
       ByteString(submissionAndPdf.pdfSummary.pdfContent),
       ContentType.`application/pdf`)
 

--- a/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
@@ -20,7 +20,7 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate.DmsSubmission
 import uk.gov.hmrc.gform.submission.{ SubmissionAndPdf, SubmissionRef }
 import uk.gov.hmrc.gform.typeclasses.Attribute
 
-import scala.xml.{ Elem, Node, Utility }
+import scala.xml.{ Elem, Utility }
 
 object MetadataXml {
 
@@ -64,13 +64,15 @@ object MetadataXml {
     </documents>
   }
 
-  def getXml(submissionRef: SubmissionRef, reconciliationId: ReconciliationId, sap: SubmissionAndPdf, dmsSubmission: DmsSubmission): Node = {
+  def getXml(submissionRef: SubmissionRef, reconciliationId: ReconciliationId, sap: SubmissionAndPdf, dmsSubmission: DmsSubmission): Elem = {
     val body = List(
       createHeader(submissionRef, reconciliationId),
       createMetadata(sap, dmsSubmission))
 
-    Utility.trim(createDocument(body))
+    trim(createDocument(body))
   }
+
+  private def trim(e: Elem): Elem = Utility.trim(e).asInstanceOf[Elem]
 
   private def createAttribute[T: Attribute](name: String, value: T): Elem =
     createAttribute(name, List(value))

--- a/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
@@ -20,7 +20,7 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate.DmsSubmission
 import uk.gov.hmrc.gform.submission.{ SubmissionAndPdf, SubmissionRef }
 import uk.gov.hmrc.gform.typeclasses.Attribute
 
-import scala.xml.Elem
+import scala.xml.{ Elem, Node, Utility }
 
 object MetadataXml {
 
@@ -42,7 +42,7 @@ object MetadataXml {
       createAttribute("cas_key", "AUDIT_SERVICE"), // We are not using CAS
       createAttribute("classification_type", dmsSubmission.classificationType),
       createAttribute("business_area", dmsSubmission.businessArea),
-      createAttribute("attachment_count", 1)) // TODO GFC-84 populate attachment count for DMS submission metedata
+      createAttribute("attachment_count", 0)) // TODO GFC-84 populate attachment count for DMS submission metedata
     <metadata></metadata>.copy(child = attributes)
   }
 
@@ -64,12 +64,12 @@ object MetadataXml {
     </documents>
   }
 
-  def getXml(submissionRef: SubmissionRef, reconciliationId: ReconciliationId, sap: SubmissionAndPdf, dmsSubmission: DmsSubmission): Elem = {
+  def getXml(submissionRef: SubmissionRef, reconciliationId: ReconciliationId, sap: SubmissionAndPdf, dmsSubmission: DmsSubmission): Node = {
     val body = List(
       createHeader(submissionRef, reconciliationId),
       createMetadata(sap, dmsSubmission))
 
-    createDocument(body)
+    Utility.trim(createDocument(body))
   }
 
   private def createAttribute[T: Attribute](name: String, value: T): Elem =

--- a/test/uk/gov/hmrc/gform/sharedmodel/MetadataXmlSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/MetadataXmlSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, FormId }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 import uk.gov.hmrc.gform.submission._
 
-import scala.xml.{ Node, Utility }
+import scala.xml.{ Elem, Utility }
 
 class MetadataXmlSpec extends Spec {
   "metadata.xml" should "be generated" in {
@@ -156,7 +156,7 @@ class MetadataXmlSpec extends Spec {
 
     val metadataXml = MetadataXml.getXml(SubmissionRef("some-submission-ref"), ReconciliationId("some-recocilliatin-id"), submissionAndPdf, dmsSubmission)
 
-    metadataXml should equal(Utility.trim(expected))(after being streamlined[Node])
+    metadataXml should equal(Utility.trim(expected).asInstanceOf[Elem])(after being streamlined[Elem])
 
   }
 }

--- a/test/uk/gov/hmrc/gform/sharedmodel/MetadataXmlSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/MetadataXmlSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, FormId }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 import uk.gov.hmrc.gform.submission._
 
-import scala.xml.Elem
+import scala.xml.{ Node, Utility }
 
 class MetadataXmlSpec extends Spec {
   "metadata.xml" should "be generated" in {
@@ -147,7 +147,7 @@ class MetadataXmlSpec extends Spec {
               <attribute_name>attachment_count</attribute_name>
               <attribute_type>int</attribute_type>
               <attribute_values>
-                <attribute_value>1</attribute_value>
+                <attribute_value>0</attribute_value>
               </attribute_values>
             </attribute>
           </metadata>
@@ -156,7 +156,7 @@ class MetadataXmlSpec extends Spec {
 
     val metadataXml = MetadataXml.getXml(SubmissionRef("some-submission-ref"), ReconciliationId("some-recocilliatin-id"), submissionAndPdf, dmsSubmission)
 
-    metadataXml should equal(expected)(after being streamlined[Elem])
+    metadataXml should equal(Utility.trim(expected))(after being streamlined[Node])
 
   }
 }


### PR DESCRIPTION
Hard code the attachment_count in DMS submission metadata to 0 for GD94, trim all whitespace from XML and use iform in the pdf filename