### PR TITLE
Revert "Bump sbt updates version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("org.scalariform"  % "sbt-scalariform" % "1.7.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4") //sbt dependencyUpdates
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0") //sbt dependencyUpdates
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 


### PR DESCRIPTION
Revert "Bump sbt updates version, previous one was not available to ci-dev"

Unnecessary change at this sensitive moment, apparent bintray outage

This reverts commit 0e45ecf