### PR TITLE
GFC-673 Remove check on number of file attachments

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
@@ -145,7 +145,7 @@ object FormTemplateValidator {
     case Address(_)                    => Valid
     case Choice(_, _, _, _, _)         => Valid
     case Group(fvs, _, _, _, _, _)     => validate(fvs.map(_.`type`), formTemplate)
-    case FileUpload()                  => validateFileUploadAmount(formTemplate.sections)
+    case FileUpload()                  => Valid
     case InformationMessage(_, _)      => Valid
   }
 
@@ -219,23 +219,6 @@ object FormTemplateValidator {
     case Sum(field1)              => evalExpr(field1)
     case id: FormCtx              => List(id.toFieldId)
     case _                        => Nil
-  }
-
-  private def validateFileUploadAmount(sections: List[Section]): ValidationResult = {
-    def countFileUpload(formComponent: FormComponent): List[FileUpload] = formComponent.`type` match {
-      case x: FileUpload => List(x)
-      case g @ Group(_, _, max, _, _, _) =>
-        g.fields
-          .flatMap(countFileUpload)
-          .flatMap(List.fill(max.getOrElse(1))(_))
-      case _ => Nil
-    }
-
-    val is = sections
-      .flatMap(section => section.fields.flatMap(countFileUpload))
-      .size <= 6 //this is set to 6 as we append to files to the envelope aswell.
-
-    isValid(is, "Form template contains too many file upload components max is 6")
   }
 
   private def isValid(is: Boolean, errorMessage: String) =

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,10 +18,11 @@
 appName = gform
 formExpiryDays = 30
 formMaxAttachmentSizeMB = 10 # looks like file upload doesn't allow to upload more than 10MB at once: 'constraints.maxSizePerItem exceeds maximum allowed value of 10.00 MB'
-formMaxAttachments = 5 # this includes the metadata and the submission pdf
-formMaxAttachmentTotalSizeMB = 24
+formMaxAttachments = 15 # this includes the metadata and the submission pdf
+formMaxAttachmentTotalSizeMB = 26
 #Below defines what kind of attachment can be uploaded to gform (file-upload)
 contentTypesSeparatedByPipe = "application/pdf|image/jpeg|application/vnd.openxmlformats-officedocument.spreadsheetml.sheet|.xlsx|application/vnd.oasis.opendocument.spreadsheet|.ods|application/vnd.openxmlformats-officedocument.wordprocessingml.document|.docx|application/vnd.oasis.opendocument.text|.odt|application/vnd.openxmlformats-officedocument.presentationml.presentation|.pptx|application/vnd.oasis.opendocument.presentation|.odp"
+play.http.parser.maxMemoryBuffer = "200K"
 
 
 # Session Timeout

--- a/test/uk/gov/hmrc/gform/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/gform/config/AppConfigSpec.scala
@@ -32,9 +32,9 @@ class AppConfigSpec extends Spec {
     val appConfig = AppConfig.loadOrThrow(ConfigFactory.load())
     appConfig.appName shouldBe "gform"
     appConfig.formExpiryDays shouldBe 30
-    appConfig.formMaxAttachments shouldBe 5
+    appConfig.formMaxAttachments shouldBe 15
     appConfig.formMaxAttachmentSizeMB shouldBe 10
-    appConfig.formMaxAttachmentTotalSizeMB shouldBe 24
+    appConfig.formMaxAttachmentTotalSizeMB shouldBe 26
     appConfig.contentTypes shouldBe List(
       ContentType.`application/pdf`,
       ContentType.`image/jpeg`,


### PR DESCRIPTION
GFC-673 Remove check on number of file attachments when validating template, validateFileUploadAmount.  The check is overly restrictive because it cannot take account of dynamic behaviour such as includeIf and uploads which are not mandatory.