### PR TITLE
GFC-624: handlebarsHttpApi destination - excluding magicCommas -

### DIFF
--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitter.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitter.scala
@@ -36,13 +36,14 @@ class RealHandlebarsHttpApiSubmitter[F[_]](
     val httpClient = RealHandlebarsHttpApiSubmitter
       .selectHttpClient(destination.profile, desHttpClient, mdgIntegrationFrameworkHttpClient)
 
+    val uri = handlebarsTemplateProcessor(destination.uri, model)
     destination.method match {
-      case HttpMethod.GET => httpClient.get(destination.uri)
+      case HttpMethod.GET => httpClient.get(uri)
       case HttpMethod.POST =>
         val body = destination.payload.fold("") {
           handlebarsTemplateProcessor(_, model)
         }
-        httpClient.postJson(destination.uri, body)
+        httpClient.postJson(uri, body)
     }
   }
 }

--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsTemplateProcessorHelpers.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsTemplateProcessorHelpers.scala
@@ -43,5 +43,17 @@ class HandlebarsTemplateProcessorHelpers(timeProvider: TimeProvider = new TimePr
   def getPeriodTo(period: String): CharSequence = getPeriodValue(period, 2)
   private def getPeriodValue(period: String, index: Int): CharSequence = ifNotNull(period) { _.split('|')(index) }
 
+  def toEtmpLegalStatus(frontEndValue: String): CharSequence = ifNotNull(frontEndValue) {
+    case "Sole trader"                   => "1"
+    case "Sole proprietor"               => "1"
+    case "Limited Liability Partnership" => "2"
+    case "Partnership"                   => "3"
+    case "Unincorporated body"           => "5"
+    case "Local authority"               => "5"
+    case "Trust"                         => "6"
+    case "Public corporation"            => "7"
+    case "Limited company"               => "7"
+  }
+
   private def ifNotNull[T, R](t: T)(f: T => R)(implicit ev: Null <:< R): R = Option(t).map(f).orNull
 }

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/PrimitiveGen.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/PrimitiveGen.scala
@@ -19,7 +19,18 @@ import cats.data.NonEmptyList
 import org.scalacheck.Gen
 
 trait PrimitiveGen {
-  def nonEmptyAlphaNumStrGen: Gen[String] = Gen.alphaNumStr.filter(_.nonEmpty)
+  def nonEmptyAsciiPrintableString: Gen[String] =
+    for {
+      f <- Gen.asciiPrintableChar
+      r <- Gen.asciiPrintableStr
+    } yield f.toString + r
+
+  def nonEmptyAlphaNumStrGen: Gen[String] =
+    for {
+      f <- Gen.alphaNumChar
+      r <- Gen.alphaNumStr
+    } yield f.toString + r
+
   def booleanGen: Gen[Boolean] = Gen.oneOf(false, true)
 
   def urlGen: Gen[String] =


### PR DESCRIPTION
Allow templating of the HandlebarsHttpApiDestination.uri