### PR TITLE
GFC-756: PDF Submission to FileUpload does not handle failure

### DIFF
--- a/app/uk/gov/hmrc/gform/core/package.scala
+++ b/app/uk/gov/hmrc/gform/core/package.scala
@@ -39,4 +39,8 @@ package object core {
 
   def fromFutureOptionA[A](fo: Future[Option[A]])(invalid: => UnexpectedState)(implicit ec: ExecutionContext): FOpt[A] =
     EitherT[Future, UnexpectedState, A](fo.map(_.toRight(invalid)))
+
+  implicit class FutureSyntax[T](f: Future[T]) {
+    def void(implicit ec: ExecutionContext): Future[Unit] = f.map(_ => ())
+  }
 }

--- a/app/uk/gov/hmrc/gform/fileupload/FileUploadService.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/FileUploadService.scala
@@ -60,22 +60,24 @@ class FileUploadService(
     val metadataXml = MetadataXml.xmlDec + "\n" + MetadataXml
       .getXml(submission, reconciliationId, summaries.pdfSummary, dmsSubmission, numberOfAttachments)
 
-    val uploadPfdF: Future[Unit] = fileUploadFrontendConnector.upload(
-      envelopeId,
-      pdf,
-      s"$fileNamePrefix-iform.pdf",
-      ByteString(summaries.pdfSummary.pdfContent),
-      ContentType.`application/pdf`)
-
-    val uploadXmlF: Future[Unit] = fileUploadFrontendConnector
-      .upload(
+    def uploadPfdF: Future[Unit] =
+      fileUploadFrontendConnector.upload(
         envelopeId,
-        xml,
-        s"$fileNamePrefix-metadata.xml",
-        ByteString(metadataXml.getBytes),
-        ContentType.`application/xml`)
+        pdf,
+        s"$fileNamePrefix-iform.pdf",
+        ByteString(summaries.pdfSummary.pdfContent),
+        ContentType.`application/pdf`)
 
-    val uploadAnyDataXmlF: Future[Unit] = summaries.xmlSummary match {
+    def uploadXmlF: Future[Unit] =
+      fileUploadFrontendConnector
+        .upload(
+          envelopeId,
+          xml,
+          s"$fileNamePrefix-metadata.xml",
+          ByteString(metadataXml.getBytes),
+          ContentType.`application/xml`)
+
+    def uploadAnyDataXmlF: Future[Unit] = summaries.xmlSummary match {
       case Some(elem) =>
         fileUploadFrontendConnector
           .upload(

--- a/app/uk/gov/hmrc/gform/wshttp/package.scala
+++ b/app/uk/gov/hmrc/gform/wshttp/package.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform
+
+import uk.gov.hmrc.http.{ HeaderCarrier, HttpResponse }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+package object wshttp {
+  implicit class FutureHttpResponseSyntax(fr: Future[HttpResponse]) {
+    def failWithNonSuccessStatusCodes(
+      url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+      fr.flatMap { response =>
+        val status = response.status
+        if (status >= 200 && status < 300) {
+          Future.successful(response)
+        } else {
+          Future.failed(new Exception(s"POST to $url failed with status $status. Response body: '${response.body}'"))
+        }
+      }
+  }
+}


### PR DESCRIPTION
Added handling of non-success HTTP response codes in relevant calls to WSHTTP