### PR TITLE
GFC-624: When posting JSON payloads to the Handlebars HTTP API destin…

### DIFF
--- a/app/uk/gov/hmrc/gform/core/package.scala
+++ b/app/uk/gov/hmrc/gform/core/package.scala
@@ -16,7 +16,9 @@
 
 package uk.gov.hmrc.gform
 
+import cats.{ Monad, MonadError }
 import cats.data.EitherT
+import cats.implicits.catsStdInstancesForFuture
 import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.gform.exceptions.UnexpectedState
 
@@ -42,5 +44,13 @@ package object core {
 
   implicit class FutureSyntax[T](f: Future[T]) {
     def void(implicit ec: ExecutionContext): Future[Unit] = f.map(_ => ())
+  }
+
+  implicit def fOptMonadError(implicit ec: ExecutionContext): MonadError[FOpt, String] = new MonadError[FOpt, String] {
+    override def flatMap[A, B](fa: FOpt[A])(f: A => FOpt[B]): FOpt[B] = fa.flatMap(f)
+    override def tailRecM[A, B](a: A)(f: A => FOpt[Either[A, B]]): FOpt[B] = implicitly[Monad[FOpt]].tailRecM(a)(f)
+    override def pure[A](x: A): FOpt[A] = success(x)
+    override def raiseError[A](e: String): FOpt[A] = fromFutureA(Future.failed(new Exception(e)))
+    override def handleErrorWith[A](fa: FOpt[A])(f: String => FOpt[A]): FOpt[A] = raiseError("Can't handle error")
   }
 }

--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.gform.submission.handlebars
 
 import uk.gov.hmrc.gform.config.ConfigModule
-import uk.gov.hmrc.gform.core.FOpt
+import uk.gov.hmrc.gform.core.{ FOpt, fOptMonadError }
 import uk.gov.hmrc.gform.wshttp._
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.gform.wshttp.HttpClient.HttpClientBuildingSyntax

--- a/test/uk/gov/hmrc/gform/core/FOptMonadErrorSpec.scala
+++ b/test/uk/gov/hmrc/gform/core/FOptMonadErrorSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.core
+
+import java.util.concurrent.TimeUnit
+
+import uk.gov.hmrc.gform.Spec
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class FOptMonadErrorSpec extends Spec {
+  "raiseError" should "work as expected" in {
+    expectFutureFailure("hello") {
+      fOptMonadError.raiseError("hello")
+    }
+  }
+
+  private def expectFutureFailure[T](expectedMessage: String)(fopt: FOpt[T]) = {
+    var result: Either[String, Unit] = Left("Future not completed yet")
+
+    fopt.value.onSuccess {
+      case v => result = Left(s"Expected a Future failure with message '$expectedMessage'. Got success with $v")
+    }
+    fopt.value.onFailure {
+      case t =>
+        result =
+          if (t.getMessage == expectedMessage) Right(())
+          else
+            Left(
+              s"Expected a Future failure with message '$expectedMessage'. Got a Future failure with message '${t.getMessage}'")
+    }
+
+    Await.ready(fopt.value, Duration(2L, TimeUnit.SECONDS))
+    result shouldBe Right(())
+  }
+}

--- a/test/uk/gov/hmrc/gform/wshttp/HeaderCarrierBuildingHttpClientSpec.scala
+++ b/test/uk/gov/hmrc/gform/wshttp/HeaderCarrierBuildingHttpClientSpec.scala
@@ -17,11 +17,12 @@
 package uk.gov.hmrc.gform.wshttp
 
 import HttpClient.HttpClientBuildingSyntax
+import cats.Id
 import org.scalacheck.Gen
 import uk.gov.hmrc.http.HeaderCarrier
 
 class HeaderCarrierBuildingHttpClientSpec extends HttpClientSpec {
-  "get" should "delegate to underlying.get with the modified HeaderCarrier" in httpClient { underlying =>
+  "get" should "delegate to underlying.get with the modified HeaderCarrier" in httpClient[Id] { underlying =>
     forAll(Gen.alphaNumStr, headerCarrierGen, headerCarrierGen, httpResponseGen) { (url, hc, hc2, response) =>
       underlying.expectGet(url, hc2, response)
 
@@ -30,7 +31,7 @@ class HeaderCarrierBuildingHttpClientSpec extends HttpClientSpec {
     }
   }
 
-  "post" should "delegate to underlying.post with the extended URL" in httpClient { underlying =>
+  "post" should "delegate to underlying.post with the extended URL" in httpClient[Id] { underlying =>
     forAll(Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, headerCarrierGen, httpResponseGen) {
       (url, postBody, hc, hc2, response) =>
         underlying.expectPost(url, postBody, hc2, response)

--- a/test/uk/gov/hmrc/gform/wshttp/JsonHttpClientSpec.scala
+++ b/test/uk/gov/hmrc/gform/wshttp/JsonHttpClientSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.wshttp
+
+import HttpClient.HttpClientBuildingSyntax
+import cats.MonadError
+import cats.syntax.either._
+import org.scalacheck.Gen
+
+class JsonHttpClientSpec extends HttpClientSpec {
+  type Possible[T] = Either[String, T]
+
+  implicit val monadError: MonadError[Possible, String] = new MonadError[Possible, String] {
+    override def raiseError[A](e: String): Possible[A] = Left(e)
+    override def flatMap[A, B](fa: Possible[A])(f: A => Possible[B]): Possible[B] = fa.flatMap(f)
+    override def pure[A](x: A): Possible[A] = Right(x)
+    override def tailRecM[A, B](a: A)(f: A => Possible[Either[A, B]]): Possible[B] = ???
+    override def handleErrorWith[A](fa: Possible[A])(f: String => Possible[A]): Possible[A] = ???
+  }
+
+  "get" should "delegate to underlying.get with no changes" in httpClient[Possible] { underlying =>
+    forAll(Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) { (uri, hc, response) =>
+      underlying.expectGet(uri, hc, response)
+
+      buildClient(underlying.httpClient)
+        .get(uri)(hc) shouldBe Right(response)
+    }
+  }
+
+  "post" should "delegate to underlying.post with no changes" in httpClient[Possible] { underlying =>
+    forAll(Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) {
+      (uri, postBody, hc, response) =>
+        underlying.expectPost(uri, postBody, hc, response)
+
+        buildClient(underlying.httpClient)
+          .post(uri, postBody)(hc) shouldBe Right(response)
+    }
+  }
+
+  "postJsonString" should "delegate to underlying.post with no changes  when the JSON string is valid" in httpClient[
+    Possible] { underlying =>
+    forAll(Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) {
+      (uri, postBody, hc, response) =>
+        underlying.expectPost(
+          uri,
+          s""""$postBody"""",
+          hc.copy(extraHeaders = ("Content-Type" -> "application/json") :: hc.extraHeaders.toList),
+          response)
+
+        buildClient(underlying.httpClient)
+          .postJsonString(uri, s""""$postBody"""")(hc) shouldBe Right(response)
+    }
+  }
+
+  it should "not delegate to underlying.post and fail when the JSON string is not valid" in httpClient[Possible] {
+    underlying =>
+      forAll(Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) { (uri, hc, response) =>
+        (buildClient(underlying.httpClient)
+          .postJsonString(uri, "fail")(hc)) match {
+          case Left(_)  => succeed
+          case Right(_) => fail("Unexpected response")
+        }
+      }
+  }
+
+  private def buildClient[F[_]](underlying: HttpClient[F])(implicit me: MonadError[F, String]): JsonHttpClient[F] =
+    underlying.json
+}

--- a/test/uk/gov/hmrc/gform/wshttp/SuccessfulResponseHttpClientSpec.scala
+++ b/test/uk/gov/hmrc/gform/wshttp/SuccessfulResponseHttpClientSpec.scala
@@ -32,7 +32,7 @@ class SuccessfulResponseHttpClientSpec extends HttpClientSpec {
     override def ap[A, B](ff: Id[A => B])(fa: Id[A]): Id[B] = ???
   }
 
-  "get" should "delegate to underlying.get with the extended URL and return any response with 200 <= status <= 299" in httpClient {
+  "get" should "delegate to underlying.get and return any response with 200 <= status <= 299" in httpClient[Id] {
     underlying =>
       forAll(Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) { (uri, hc, response) =>
         whenever(successful(response)) {
@@ -44,16 +44,17 @@ class SuccessfulResponseHttpClientSpec extends HttpClientSpec {
       }
   }
 
-  "post" should "delegate to underlying.post with the extended URL" in httpClient { underlying =>
-    forAll(Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) {
-      (uri, postBody, hc, response) =>
-        whenever(successful(response)) {
-          underlying.expectPost(uri, postBody, hc, response)
+  "post" should "delegate to underlying.post and return any response with 200 <= status <= 299" in httpClient[Id] {
+    underlying =>
+      forAll(Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, successfulHttpResponseGen) {
+        (uri, postBody, hc, response) =>
+          whenever(successful(response)) {
+            underlying.expectPost(uri, postBody, hc, response)
 
-          buildClient(underlying.httpClient)
-            .post(uri, postBody)(hc) shouldBe response
-        }
-    }
+            buildClient(underlying.httpClient)
+              .post(uri, postBody)(hc) shouldBe response
+          }
+      }
   }
 
   private def successful(response: HttpResponse) = response.status >= 200 && response.status < 300

--- a/test/uk/gov/hmrc/gform/wshttp/UriBuildingHttpClientSpec.scala
+++ b/test/uk/gov/hmrc/gform/wshttp/UriBuildingHttpClientSpec.scala
@@ -17,10 +17,11 @@
 package uk.gov.hmrc.gform.wshttp
 
 import HttpClient.HttpClientBuildingSyntax
+import cats.Id
 import org.scalacheck.Gen
 
 class UriBuildingHttpClientSpec extends HttpClientSpec {
-  "get" should "delegate to underlying.get with the extended URL" in httpClient { underlying =>
+  "get" should "delegate to underlying.get with the extended URL" in httpClient[Id] { underlying =>
     forAll(Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, httpResponseGen) { (uri, uri2, hc, response) =>
       underlying.expectGet(uri2, hc, response)
 
@@ -29,7 +30,7 @@ class UriBuildingHttpClientSpec extends HttpClientSpec {
     }
   }
 
-  "post" should "delegate to underlying.post with the extended URL" in httpClient { underlying =>
+  "post" should "delegate to underlying.post with the extended URL" in httpClient[Id] { underlying =>
     forAll(Gen.alphaNumStr, Gen.alphaNumStr, Gen.alphaNumStr, headerCarrierGen, httpResponseGen) {
       (uri, uri2, postBody, hc, response) =>
         underlying.expectPost(uri2, postBody, hc, response)


### PR DESCRIPTION
When posting JSON payloads to the Handlebars HTTP API destinations, validate that the JSON body being sent to the endpoint is actually JSON before sending it. The idea is to report errors better during testing of payloads in the templates.