### PR TITLE
Retrofit changes from v0.178.3

### DIFF
--- a/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
@@ -34,7 +34,7 @@ object MetadataXml {
     val attributes = List(
       createAttribute("hmrc_time_of_receipt", submission.submittedDate),
       createAttribute("time_xml_created", submission.submittedDate),
-      createAttribute("submission_reference", submission.submissionRef.value),
+      createAttribute("submission_reference", submission.submissionRef.value.replace("-", "")),
       createAttribute("form_id", dmsSubmission.dmsFormId),
       createAttribute("number_pages", pdfSummary.numberOfPages),
       createAttribute("source", "dfs"),
@@ -50,7 +50,7 @@ object MetadataXml {
 
   private def createHeader(submissionRef: SubmissionRef, reconciliationId: ReconciliationId): Elem =
     <header>
-      <title>{ submissionRef.value }</title>
+      <title>{ submissionRef.value.replace("-", "") }</title>
       <format>pdf</format>
       <mime_type>application/pdf</mime_type>
       <store>true</store>

--- a/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/MetadataXml.scala
@@ -34,7 +34,7 @@ object MetadataXml {
     val attributes = List(
       createAttribute("hmrc_time_of_receipt", submission.submittedDate),
       createAttribute("time_xml_created", submission.submittedDate),
-      createAttribute("submission_reference", submission.submissionRef.value.replace("-", "")),
+      createAttribute("submission_reference", submission.submissionRef.withoutHyphens),
       createAttribute("form_id", dmsSubmission.dmsFormId),
       createAttribute("number_pages", pdfSummary.numberOfPages),
       createAttribute("source", "dfs"),
@@ -50,7 +50,7 @@ object MetadataXml {
 
   private def createHeader(submissionRef: SubmissionRef, reconciliationId: ReconciliationId): Elem =
     <header>
-      <title>{ submissionRef.value.replace("-", "") }</title>
+      <title>{ submissionRef.withoutHyphens }</title>
       <format>pdf</format>
       <mime_type>application/pdf</mime_type>
       <store>true</store>

--- a/app/uk/gov/hmrc/gform/fileupload/model.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/model.scala
@@ -44,7 +44,7 @@ object ReconciliationId {
 
   def create(submissionRef: SubmissionRef)(implicit now: Now[LocalDateTime]): ReconciliationId = {
     val dateFormatter = now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
-    ReconciliationId(submissionRef + "-" + dateFormatter)
+    ReconciliationId(submissionRef.value.replace("-", "") + "-" + dateFormatter)
   }
 }
 

--- a/app/uk/gov/hmrc/gform/fileupload/model.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/model.scala
@@ -44,7 +44,7 @@ object ReconciliationId {
 
   def create(submissionRef: SubmissionRef)(implicit now: Now[LocalDateTime]): ReconciliationId = {
     val dateFormatter = now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
-    ReconciliationId(submissionRef.value.replace("-", "") + "-" + dateFormatter)
+    ReconciliationId(submissionRef.withoutHyphens + "-" + dateFormatter)
   }
 }
 

--- a/app/uk/gov/hmrc/gform/sharedmodel/form/Form.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/form/Form.scala
@@ -20,7 +20,7 @@ import julienrf.json.derived
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.gform.sharedmodel.{ Obligations, UserId }
+import uk.gov.hmrc.gform.sharedmodel.{ NotChecked, Obligations, UserId }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormTemplateId, SectionNumber }
 
 case class VisitIndex(visitsIndex: Set[Int]) extends AnyVal
@@ -50,6 +50,9 @@ object Form {
   val readVisitIndex: Reads[VisitIndex] =
     (__ \ "visitsIndex").readNullable[List[Int]].map(a => VisitIndex(a.fold(Set.empty[Int])(_.toSet)))
 
+  val readObligations: Reads[Obligations] =
+    (__ \ "obligations").readNullable[Obligations].map(a => a.getOrElse(NotChecked))
+
   private val reads: Reads[Form] = ((FormId.format: Reads[FormId]) and
     EnvelopeId.format and
     UserId.oformat and
@@ -58,7 +61,7 @@ object Form {
     FormStatus.format and
     readVisitIndex and
     EnvelopeExpiryDate.optionFormat and
-    Obligations.format)(Form.apply _)
+    readObligations)(Form.apply _)
 
   private val writes: OWrites[Form] = OWrites[Form](
     form =>

--- a/app/uk/gov/hmrc/gform/submission/SubmissionRef.scala
+++ b/app/uk/gov/hmrc/gform/submission/SubmissionRef.scala
@@ -29,6 +29,7 @@ import scala.util.Random
 
 case class SubmissionRef(value: String) extends AnyVal {
   override def toString = value
+  def withoutHyphens = value.replace("-", "")
 }
 
 object SubmissionRef {

--- a/test/uk/gov/hmrc/gform/sharedmodel/MetadataXmlSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/MetadataXmlSpec.scala
@@ -52,7 +52,7 @@ class MetadataXmlSpec extends Spec {
       <documents xmlns="http://govtalk.gov.uk/hmrc/gis/content/1">
         <document>
           <header>
-            <title>some-submission-ref</title>
+            <title>somesubmissionref</title>
             <format>pdf</format>
             <mime_type>application/pdf</mime_type>
             <store>true</store>
@@ -79,7 +79,7 @@ class MetadataXmlSpec extends Spec {
               <attribute_name>submission_reference</attribute_name>
               <attribute_type>string</attribute_type>
               <attribute_values>
-                <attribute_value>some-submission-ref</attribute_value>
+                <attribute_value>somesubmissionref</attribute_value>
               </attribute_values>
             </attribute>
             <attribute>

--- a/test/uk/gov/hmrc/gform/sharedmodel/ReconciliationIdSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/ReconciliationIdSpec.scala
@@ -35,7 +35,7 @@ class ReconciliationIdSpec extends Spec {
 
     val res = ReconciliationId.create(submissionRef)
 
-    res.value should be("6FJX-HVQL-U4FD-20170131135345")
+    res.value should be("6FJXHVQLU4FD-20170131135345")
 
   }
 }

--- a/test/uk/gov/hmrc/gform/sharedmodel/form/FormSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/form/FormSpec.scala
@@ -68,7 +68,7 @@ class FormSpec extends FlatSpec with Matchers {
     Form.format.reads(Form.format.writes(form)) should be(JsSuccess(form))
   }
 
-  it should "handle inflight forms not having visitsIndex" in {
+  it should "handle inflight forms not having visitsIndex or obligations" in {
     val inflight = Json.obj(
       "_id"            -> "James007-AAA999",
       "envelopeId"     -> "b66c5979-e885-49cd-9281-c7f42ce6b307",
@@ -78,8 +78,7 @@ class FormSpec extends FlatSpec with Matchers {
         .arr(
           Json.obj("id" -> "facePhoto", "value"      -> "face-photo.jpg"),
           Json.obj("id" -> "startDate-year", "value" -> "2008")),
-      "InProgress" -> Json.obj(),
-      "NotChecked" -> Json.obj()
+      "InProgress" -> Json.obj()
     )
 
     val expectedForm = form.copy(visitsIndex = VisitIndex.empty, envelopeExpiryDate = None)


### PR DESCRIPTION
retrofit from v0.178.3

GFC-791 Accept in flight form without obligations object present & GFC-740 remove hyphens from submission_reference property, reconcilliation_id and the XML Title
