### PR TITLE
GFORMS-910 - Fix issue preventing expression user.enrolments.[SERVICE…

### DIFF
--- a/app/uk/gov/hmrc/gform/core/parsers/ValueParser.scala
+++ b/app/uk/gov/hmrc/gform/core/parsers/ValueParser.scala
@@ -195,7 +195,7 @@ object ValueParser {
     ServiceName(str)
   }
 
-  lazy val identifierName: Parser[IdentifierName] = """[^.}]+""".r ^^ { (loc, str) =>
+  lazy val identifierName: Parser[IdentifierName] = """[^.= }]+""".r ^^ { (loc, str) =>
     IdentifierName(str)
   }
 

--- a/test/uk/gov/hmrc/gform/core/parsers/ValueParserSpec.scala
+++ b/test/uk/gov/hmrc/gform/core/parsers/ValueParserSpec.scala
@@ -160,7 +160,7 @@ class ValueParserSpec extends Spec {
       // format: off
       ("serviceName", "identifierName"),
       ("HMRC-AS-AGENT", "AgentReferenceNumber"),
-      ("HMRC AS-AGENT", "Agent Reference Number"),
+      ("HMRC AS-AGENT", "AgentReferenceNumber"),
       ("test-{{}}}}", ")(*&^%$#@@@)")
       // format: on
     )
@@ -170,7 +170,9 @@ class ValueParserSpec extends Spec {
       ("serviceName", "identifierName"),
       ("HMRC.AA.AGENT", "AgentReferenceNumber"),  // serviceName    cannot include `.`
       ("HMRC-AS-AGENT", "Agent.ReferenceNumber"), // identifierName cannot include `.`
-      ("HMRC-AS-AGENT", "Agent}ReferenceNumber")  // identifierName cannot include `}`
+      ("HMRC-AS-AGENT", "Agent}ReferenceNumber"), // identifierName cannot include `}`
+      ("HMRC-AS-AGENT", "Agent ReferenceNumber"), // identifierName cannot include ` `
+      ("HMRC-AS-AGENT", "Agent=ReferenceNumber")  // identifierName cannot include `=`
       // format: on
     )
 


### PR DESCRIPTION
…].[IDENTIFIER] being used in includeIf