### PR TITLE
GFORMS-1674, GFORMS-2006: 

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/FormComponentMaker.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormComponentMaker.scala
@@ -64,6 +64,11 @@ class FormComponentMaker(json: JsValue) {
     case _                                => Right(false)
   }
 
+  lazy val optNotPII: Opt[Boolean] = (json \ "notPII") match {
+    case JsDefined(JsString(IsTrueish())) => Right(true)
+    case _                                => Right(false)
+  }
+
   def optFileUploadProvider(compression: Boolean): Opt[FileUploadProvider] = (json \ "service") match {
     case JsDefined(JsString("upscan"))     => Right(FileUploadProvider.Upscan(compression))
     case JsDefined(JsString("fileUpload")) => Right(FileUploadProvider.FileUploadFrontend)
@@ -281,6 +286,7 @@ class FormComponentMaker(json: JsValue) {
       includeIf   <- optIncludeIf
       validIf     <- optValidIf
       labelSize   <- optLabelSize
+      notPII      <- optNotPII
     } yield mkFieldValue(label, helpText, presHint, mes, ct, validators, instruction, includeIf, validIf, labelSize)
 
   private def toOpt[A](result: JsResult[A], pathPrefix: String): Opt[A] =
@@ -306,7 +312,8 @@ class FormComponentMaker(json: JsValue) {
     instruction: Option[Instruction],
     includeIf: Option[IncludeIf],
     validIf: Option[ValidIf],
-    labelSize: Option[LabelSize]
+    labelSize: Option[LabelSize],
+    notPII: Boolean
   ): FormComponent =
     FormComponent(
       id = id,
@@ -328,7 +335,8 @@ class FormComponentMaker(json: JsValue) {
       labelSize = labelSize,
       errorShortName = errorShortName,
       errorShortNameStart = errorShortNameStart,
-      errorExample = errorExample
+      errorExample = errorExample,
+      notPII = notPII
     )
 
   private lazy val optMES: Opt[MES] = (submitMode, mandatory, optMaybeValueExpr) match {

--- a/app/uk/gov/hmrc/gform/formtemplate/FormComponentMaker.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormComponentMaker.scala
@@ -287,7 +287,19 @@ class FormComponentMaker(json: JsValue) {
       validIf     <- optValidIf
       labelSize   <- optLabelSize
       notPII      <- optNotPII
-    } yield mkFieldValue(label, helpText, presHint, mes, ct, validators, instruction, includeIf, validIf, labelSize)
+    } yield mkFieldValue(
+      label,
+      helpText,
+      presHint,
+      mes,
+      ct,
+      validators,
+      instruction,
+      includeIf,
+      validIf,
+      labelSize,
+      notPII
+    )
 
   private def toOpt[A](result: JsResult[A], pathPrefix: String): Opt[A] =
     result match {

--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
@@ -296,6 +296,24 @@ object FormTemplateValidator {
     Monoid.combineAll(List(mrc.result, functionsChecker.result))
   }
 
+  def validateErrorMessageConstraints(
+    formTemplate: FormTemplate,
+    allExpressions: List[ExprWithPath]
+  ): ValidationResult = {
+    val invalidResults: List[ValidationResult] = allExpressions.flatMap(_.referenceInfos) collect {
+      case FormCtxExpr(path, FormCtx(fcId))
+          if path.subpaths.contains("errorMessage") && !noPIIFcIds(formTemplate).contains(fcId) =>
+        Invalid(s"""${path.path} contains PII fcId: ${fcId.value}""")
+    }
+    Monoid.combineAll(invalidResults)
+  }
+
+  private def noPIIFcIds(formTemplate: FormTemplate): List[FormComponentId] =
+    (formTemplate.destinations.allFormComponents ++
+      SectionHelper.allSectionsFormComponents(formTemplate.formKind.allSections))
+      .filter(_.notPII)
+      .map(f => f.id)
+
   def validateAddressReferencesConstraints(
     formTemplate: FormTemplate,
     allExpressions: List[ExprWithPath]

--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
@@ -335,7 +335,7 @@ object FormTemplateValidator {
     formTemplate.formKind.allSections
       .flatMap(
         _.fold(n => check(n.page.title, n.page.noPIITitle, titleMessage))(r =>
-          check(r.title, r.page.noPIITitle, titleMessage)
+          check(r.title(), r.page.noPIITitle, titleMessage)
         )(a =>
           check(a.title, a.noPIITitle, titleMessage)
             ++ a.defaultPage.toList.flatMap(p => check(p.title, p.noPIITitle, titleMessage))

--- a/app/uk/gov/hmrc/gform/formtemplate/SectionHelper.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/SectionHelper.scala
@@ -45,4 +45,9 @@ object SectionHelper {
       case s: Section.AddToList => s.pages.toList.flatMap(_.fields)
       case _                    => Nil
     }
+
+  def allSectionsFormComponents(sections: List[Section]): List[FormComponent] =
+    pages(sections).flatMap(_.allFormComponents) ++
+      addToListFormComponents(sections) ++
+      sections.flatMap(addToListRepeaterAndDefaultPages)
 }

--- a/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
@@ -75,6 +75,7 @@ trait Verifier {
       _ <- fromOptA(FormTemplateValidator.validateInvalidReferences(formTemplate).toEither)
       _ <- fromOptA(FormTemplateValidator.validateReferencesConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(FormTemplateValidator.validateErrorMessageConstraints(formTemplate, allExpressions).toEither)
+      _ <- fromOptA(FormTemplateValidator.validateNoPIITitleConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(FormTemplateValidator.validateAddressReferencesConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(FormTemplateValidator.validatePeriodFunReferenceConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(

--- a/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
@@ -74,6 +74,7 @@ trait Verifier {
       _ <- fromOptA(FormTemplateValidator.validateInstructions(pages).toEither)
       _ <- fromOptA(FormTemplateValidator.validateInvalidReferences(formTemplate).toEither)
       _ <- fromOptA(FormTemplateValidator.validateReferencesConstraints(formTemplate, allExpressions).toEither)
+      _ <- fromOptA(FormTemplateValidator.validateErrorMessageConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(FormTemplateValidator.validateAddressReferencesConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(FormTemplateValidator.validatePeriodFunReferenceConstraints(formTemplate, allExpressions).toEither)
       _ <- fromOptA(

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormComponent.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormComponent.scala
@@ -43,7 +43,8 @@ case class FormComponent(
   labelSize: Option[LabelSize] = None,
   errorShortName: Option[SmartString] = None,
   errorShortNameStart: Option[SmartString] = None,
-  errorExample: Option[SmartString] = None
+  errorExample: Option[SmartString] = None,
+  notPII: Boolean = false
 ) {
   private def updateField(i: Int, fc: FormComponent): FormComponent =
     fc.copy(

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/LeafExpr.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/LeafExpr.scala
@@ -26,6 +26,8 @@ case class TemplatePath(path: String) extends AnyVal {
     TemplatePath(subPath)
   else
     TemplatePath(path + "." + subPath)
+
+  def subpaths: List[String] = path.split('.').toList
 }
 
 object TemplatePath {

--- a/test/uk/gov/hmrc/gform/formtemplate/FormTemplateSupport.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/FormTemplateSupport.scala
@@ -20,6 +20,7 @@ import cats.data.NonEmptyList
 import uk.gov.hmrc.gform.Helpers.toSmartString
 import uk.gov.hmrc.gform.sharedmodel.{ ExampleData, LangADT, LocalisedString }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.sharedmodel.SmartString
 
 trait FormTemplateSupport {
 
@@ -155,6 +156,69 @@ trait FormTemplateSupport {
       Nil,
       None,
       labelSize
+    )
+
+  def mkFormComponentWithErrorMessage(id: String, errorMessage: Option[SmartString] = None) =
+    FormComponent(
+      FormComponentId(id),
+      Text(ShortText.default, Value),
+      toSmartString(id),
+      None,
+      None,
+      None,
+      None,
+      true,
+      false,
+      true,
+      false,
+      false,
+      errorMessage,
+      None,
+      Nil,
+      None
+    )
+
+  def mkFormComponentWithNotPII(id: String, notPII: Boolean = false) =
+    FormComponent(
+      FormComponentId(id),
+      Text(ShortText.default, Value),
+      toSmartString(id),
+      None,
+      None,
+      None,
+      None,
+      true,
+      false,
+      true,
+      false,
+      false,
+      None,
+      None,
+      Nil,
+      None,
+      None,
+      notPII
+    )
+
+  def mkFormComponentWithValidators(id: String, validators: List[FormComponentValidator] = Nil) =
+    FormComponent(
+      FormComponentId(id),
+      Text(ShortText.default, Value),
+      toSmartString(id),
+      None,
+      None,
+      None,
+      None,
+      true,
+      false,
+      true,
+      false,
+      false,
+      None,
+      None,
+      validators,
+      None,
+      None
     )
 
   def mkSection(name: String, formComponents: List[FormComponent], instruction: Option[Instruction]) =

--- a/test/uk/gov/hmrc/gform/formtemplate/FormTemplateSupport.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/FormTemplateSupport.scala
@@ -197,6 +197,9 @@ trait FormTemplateSupport {
       Nil,
       None,
       None,
+      None,
+      None,
+      None,
       notPII
     )
 


### PR DESCRIPTION
GFORMS-2006: Only allow smart strings to be used in error messages
GFORMS-1674: DAC - Non-descriptive page title - Ensure noPIITitle present when required