### PR TITLE
GFORMS-2033 - Test end to end gForm-objectStore submission

### DIFF
--- a/app/uk/gov/hmrc/gform/ApplicationLoader.scala
+++ b/app/uk/gov/hmrc/gform/ApplicationLoader.scala
@@ -220,7 +220,9 @@ class ApplicationModule(context: Context)
       formService,
       formTemplateModule.formTemplateService,
       destinationModule,
-      controllerComponents
+      controllerComponents,
+      objectStoreModule,
+      akkaModule
     )
 
   val dbLookupModule = new DbLookupModule(controllerComponents, mongoModule)

--- a/app/uk/gov/hmrc/gform/objectstore/ObjectStoreConnector.scala
+++ b/app/uk/gov/hmrc/gform/objectstore/ObjectStoreConnector.scala
@@ -20,13 +20,14 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import uk.gov.hmrc.gform.models.helpers.ObjectStoreHelper._
 import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.objectstore.client
 import uk.gov.hmrc.objectstore.client.config.ObjectStoreClientConfig
+import uk.gov.hmrc.objectstore.client.play.Implicits._
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 import uk.gov.hmrc.objectstore.client.{ ObjectSummaryWithMd5, Path }
-import uk.gov.hmrc.objectstore.client.play.Implicits._
-import uk.gov.hmrc.gform.models.helpers.ObjectStoreHelper._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -81,4 +82,11 @@ class ObjectStoreConnector(
     objectStoreClient.deleteObject(
       path = Path.Directory(zipDirectory).file(s"${envelopeId.value}$zipExtension")
     )
+
+  def getZipFile(envelopeId: EnvelopeId)(implicit
+    hc: HeaderCarrier
+  ): Future[Option[client.Object[Source[ByteString, NotUsed]]]] =
+    objectStoreClient
+      .getObject(path = Path.Directory(zipDirectory).file(s"${envelopeId.value}$zipExtension"))
+
 }

--- a/app/uk/gov/hmrc/gform/objectstore/ObjectStoreModule.scala
+++ b/app/uk/gov/hmrc/gform/objectstore/ObjectStoreModule.scala
@@ -16,6 +16,9 @@
 
 package uk.gov.hmrc.gform.objectstore
 
+import akka.NotUsed
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.libs.ws.WSClient
 import uk.gov.hmrc.gform.akka.AkkaModule
@@ -26,9 +29,10 @@ import uk.gov.hmrc.gform.sharedmodel.config.ContentType
 import uk.gov.hmrc.gform.sharedmodel.envelope.EnvelopeData
 import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, FileId }
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.objectstore.client.{ ObjectSummaryWithMd5, RetentionPeriod }
+import uk.gov.hmrc.objectstore.client
 import uk.gov.hmrc.objectstore.client.config.ObjectStoreClientConfig
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import uk.gov.hmrc.objectstore.client.{ ObjectSummaryWithMd5, RetentionPeriod }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -91,5 +95,10 @@ class ObjectStoreModule(
 
     override def deleteZipFile(envelopeId: EnvelopeId)(implicit hc: HeaderCarrier): FOpt[Unit] =
       fromFutureA(objectStoreService.deleteZipFile(envelopeId))
+
+    override def getZipFile(
+      envelopeId: EnvelopeId
+    )(implicit hc: HeaderCarrier, m: Materializer): FOpt[Option[client.Object[Source[ByteString, NotUsed]]]] =
+      fromFutureA(objectStoreService.getZipFile(envelopeId))
   }
 }

--- a/app/uk/gov/hmrc/gform/playcomponents/PlayComponentsModule.scala
+++ b/app/uk/gov/hmrc/gform/playcomponents/PlayComponentsModule.scala
@@ -110,7 +110,8 @@ class PlayComponentsModule(
       errorHandler,
       prodRoutes,
       testOnlyModule.testOnlyController,
-      testOnlyModule.fUInterceptor
+      testOnlyModule.fUInterceptor,
+      testOnlyModule.testOnlyObjectStoreController
     )
 
   lazy val router: Router = {

--- a/app/uk/gov/hmrc/gform/testonly/TestOnlyModule.scala
+++ b/app/uk/gov/hmrc/gform/testonly/TestOnlyModule.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.gform.testonly
 
 import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.gform.akka.AkkaModule
 
 import scala.concurrent.Future
 import uk.gov.hmrc.gform.config.ConfigModule
@@ -24,6 +25,7 @@ import uk.gov.hmrc.gform.des.DesConnector
 import uk.gov.hmrc.gform.form.FormService
 import uk.gov.hmrc.gform.formtemplate.{ FormTemplateAlgebra, FormTemplateService }
 import uk.gov.hmrc.gform.mongo.MongoModule
+import uk.gov.hmrc.gform.objectstore.ObjectStoreModule
 import uk.gov.hmrc.gform.playcomponents.PlayComponents
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormTemplate, FormTemplateId }
 import uk.gov.hmrc.gform.submission.destinations.DestinationModule
@@ -39,7 +41,9 @@ class TestOnlyModule(
   formService: FormService[Future],
   formTemplateService: FormTemplateService,
   destinationModule: DestinationModule,
-  controllerComponents: ControllerComponents
+  controllerComponents: ControllerComponents,
+  objectStoreModule: ObjectStoreModule,
+  akkaModule: AkkaModule
 )(implicit ex: ExecutionContext) {
 
   val enrolmentConnector =
@@ -78,4 +82,9 @@ class TestOnlyModule(
       configModule.serviceConfig,
       proxyActions
     )
+
+  val testOnlyObjectStoreController: TestOnlyObjectStoreController = new TestOnlyObjectStoreController(
+    configModule.controllerComponents,
+    objectStoreModule.objectStoreService
+  )(ex, akkaModule.materializer)
 }

--- a/app/uk/gov/hmrc/gform/testonly/TestOnlyObjectStoreController.scala
+++ b/app/uk/gov/hmrc/gform/testonly/TestOnlyObjectStoreController.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.testonly
+
+import akka.stream.Materializer
+import play.api.mvc.{ ControllerComponents, Results }
+import uk.gov.hmrc.gform.controllers.BaseController
+import uk.gov.hmrc.gform.objectstore.ObjectStoreAlgebra
+import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class TestOnlyObjectStoreController(
+  controllerComponents: ControllerComponents,
+  objectStoreAlgebra: ObjectStoreAlgebra[Future]
+)(implicit
+  ex: ExecutionContext,
+  m: Materializer
+) extends BaseController(controllerComponents) {
+
+  def downloadZip(envelopeId: EnvelopeId) = Action.async { implicit request =>
+    objectStoreAlgebra.getZipFile(envelopeId) map {
+      case Some(objectSource) =>
+        Ok.streamed(
+          objectSource.content,
+          contentLength = Some(objectSource.metadata.contentLength),
+          contentType = Some(objectSource.metadata.contentType)
+        ).as("application/zip")
+          .withHeaders(
+            Results.contentDispositionHeader(inline = false, name = Some(s"${envelopeId.value}.zip")).toList: _*
+          )
+      case None => BadRequest(s"Envelope with id: $envelopeId not found")
+    }
+  }
+
+}

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -32,3 +32,5 @@ POST          /gform/test-only/file-upload-interceptor/set-response/*path       
 GET           /gform/test-only/file-upload-interceptor/get-responses             uk.gov.hmrc.gform.testonly.FUInterceptorController.getPredefinedResponses()
 
 GET           /gform/test-only/getFromDes/*path                                  uk.gov.hmrc.gform.testonly.TestOnlyController.getFromDes(path: String)
+
+GET           /gform/test-only/object-store/envelopes/:envelopeId                uk.gov.hmrc.gform.testonly.TestOnlyObjectStoreController.downloadZip(envelopeId: EnvelopeId)


### PR DESCRIPTION
Added a test-only endpoint to allow us to download the zipped files from object-store