### PR TITLE
GFORMS-2279 - Deprecate "validatorName": "hmrcRosmRegistrationCheck" …

### DIFF
--- a/conf/formTemplateSchema.json
+++ b/conf/formTemplateSchema.json
@@ -394,9 +394,6 @@
         "repeatsMax": {
           "type": "string"
         },
-        "validators": {
-          "type": "object"
-        },
         "confirmation": {
           "type": "object"
         },


### PR DESCRIPTION
…once all forms updated with new implementation