### PR TITLE
GFORMS-2558: Add Schema Check so that Properties that Allow Strings only Allow Objects with en and cy and no Other Properties

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.formtemplate
+
+import cats.data.NonEmptyList
+import io.circe.{ DecodingFailure, Json }
+import io.circe.schema.ValidationError
+import uk.gov.hmrc.gform.exceptions.SchemaValidationException
+
+import scala.annotation.tailrec
+
+object JsonSchemeErrorParser {
+
+  def parseErrorMessages(errors: NonEmptyList[ValidationError], schema: Json, json: Json): SchemaValidationException = {
+    val parsedErrors: NonEmptyList[ValidationError] = errors.map { error =>
+      val parsedErrorMessage: String =
+        if (error.schemaLocation.getOrElse("").contains("dependencies")) {
+          parseConditionalValidationErrorMessage(schema, json, error)
+        } else if (errors.filter(_.location == error.location).map(_.keyword).contains("type")) {
+          parseTypeError(error, errors, json, schema)
+        } else {
+          error.getMessage
+        }
+
+      ValidationError(error.keyword, parsedErrorMessage, error.location, error.schemaLocation)
+    }
+
+    SchemaValidationException(parsedErrors.map(_.getMessage).distinct)
+  }
+
+  private def parseConditionalValidationErrorMessage(schema: Json, json: Json, error: ValidationError): String =
+    error.keyword match {
+      case "pattern" =>
+        parsePatternConditionalValidationError(schema, json, error)
+
+      case "required" =>
+        parseRequiredConditionalValidationError(schema, json, error)
+
+      case _ => error.getMessage
+    }
+
+  private def parsePatternConditionalValidationError(schema: Json, json: Json, error: ValidationError): String = {
+    val errorLocation: String = tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = true)
+
+    val maybeRequirements: Either[DecodingFailure, Json] =
+      goDownSchema(
+        schema,
+        error.schemaLocation.getOrElse("").split("/").tail.toList.dropRight(1)
+      )
+
+    val property: String = error.schemaLocation
+      .getOrElse("")
+      .split("/")(error.schemaLocation.getOrElse("").split("/").length - 3)
+
+    getErrorMessageFromConditionalRequirements(maybeRequirements, error, errorLocation, property)
+  }
+
+  private def parseRequiredConditionalValidationError(schema: Json, json: Json, error: ValidationError): String = {
+    val errorLocation: String = tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = false)
+
+    val maybeRequirements: Either[DecodingFailure, Json] =
+      goDownSchema(
+        schema,
+        error.schemaLocation.getOrElse("").split("/").tail.toList ++ List("properties")
+      )
+
+    val property: String = error.schemaLocation
+      .getOrElse("")
+      .split("/")
+      .last
+
+    getErrorMessageFromConditionalRequirements(maybeRequirements, error, errorLocation, property)
+  }
+
+  private def tryConvertErrorLocationToId(json: Json, location: String, propertyNameInLocation: Boolean): String = {
+    val errorLocationSections: List[String] = location.split("/").tail.toList
+    val errorLocationSectionsWithoutProperty: List[String] =
+      if (propertyNameInLocation) errorLocationSections.dropRight(1) else errorLocationSections
+
+    // If cannot get ID of location, use original location message instead
+    getErrorLocationId(json, errorLocationSectionsWithoutProperty).flatMap(_.asString).getOrElse(location)
+  }
+
+  @tailrec
+  private def getErrorLocationId(json: Json, remainingSections: List[String]): Option[Json] =
+    remainingSections match {
+      // No more sections to traverse, so get ID of current section to return
+      case Nil =>
+        json.hcursor.downField("id").as[Json] match {
+          case Left(_)                => None
+          case Right(errorLocationId) => Some(errorLocationId)
+        }
+
+      // More sections to traverse, so check if current json is a List of Json or a Json
+      case section :: nextRemainingSections =>
+        json.as[List[Json]] match {
+
+          // If Json, go to next section
+          case Left(_) =>
+            json.hcursor.downField(section).as[Json] match {
+              case Left(_)                => None
+              case Right(nextJsonSection) => getErrorLocationId(nextJsonSection, nextRemainingSections)
+            }
+
+          // If List of Json, get Int of next section and index the List to go to next section
+          case Right(jsonList) =>
+            section.toIntOption match {
+              case Some(sectionInt) => getErrorLocationId(jsonList(sectionInt), nextRemainingSections)
+              case None             => None
+            }
+        }
+    }
+
+  @tailrec
+  private def goDownSchema(schema: Json, remaining: List[String]): Either[DecodingFailure, Json] =
+    remaining match {
+      case Nil => Right(schema)
+      case current :: next =>
+        schema.hcursor
+          .downField(current)
+          .as[Json] match {
+          case Left(value)  => Left(value)
+          case Right(value) => goDownSchema(value, next)
+        }
+    }
+
+  private def getErrorMessageFromConditionalRequirements(
+    maybeRequirements: Either[DecodingFailure, Json],
+    error: ValidationError,
+    errorLocation: String,
+    property: String
+  ): String =
+    maybeRequirements match {
+      case Left(_) => error.getMessage
+      case Right(requirements: Json) =>
+        requirements.as[Map[String, Map[String, String]]] match {
+          case Left(_) => error.getMessage
+          case Right(value) =>
+            val errorMessage: String =
+              s"Property $property can only be used with ${requiredPropertyValuesFromPattern(value)}"
+            constructCustomErrorMessage(errorLocation, errorMessage)
+        }
+    }
+
+  private def requiredPropertyValuesFromPattern(requiredPropertyAndPattern: Map[String, Map[String, String]]): String =
+    requiredPropertyAndPattern.view
+      .mapValues { requiredPattern =>
+        requiredPattern.values
+          .map { requiredValues =>
+            requiredValues.substring(1, requiredValues.length - 1).replace("|", ", ")
+          }
+          .mkString(", ")
+      }
+      .map { case (requiredProperty, requiredValues) =>
+        if (requiredValues.contains("?!")) {
+          s"$requiredProperty not: [${requiredValues.substring(4, requiredValues.length - 4)}]"
+        } else {
+          s"$requiredProperty: [$requiredValues]"
+        }
+      }
+      .mkString(", ")
+
+  private def constructCustomErrorMessage(errorLocation: String, errorMessage: String): String =
+    s"Error at ${if (!errorLocation.startsWith("#")) "ID " else ""}<$errorLocation>: $errorMessage"
+
+  private def parseTypeError(
+    error: ValidationError,
+    errors: NonEmptyList[ValidationError],
+    json: Json,
+    schema: Json
+  ): String = {
+    val allSameErrors: List[ValidationError] = errors.filter(_.location == error.location)
+    if (allSameErrors.map(_.schemaLocation).exists(_.contains("#/$defs/stringOrEnCyObject"))) {
+      parseEnCyTypeError(allSameErrors, json, error)
+    } else {
+      parseNormalTypeError(schema, json, error, errors)
+    }
+  }
+
+  private def parseEnCyTypeError(allSameErrors: List[ValidationError], json: Json, error: ValidationError) = {
+    val maybeInvalidKeyMessage: Option[String] = keysFromErrorMessage(allSameErrors, "additionalProperties") match {
+      case Nil         => None
+      case invalidKeys => Some(s"Invalid key(s) [${invalidKeys.mkString(", ")}] are not permitted")
+    }
+
+    val maybeRequiredKeyMessage: Option[String] = keysFromErrorMessage(allSameErrors, "required") match {
+      case Nil          => None
+      case requiredKeys => Some(s"Missing key(s) [${requiredKeys.mkString(", ")}] are required")
+    }
+
+    List(Some(constructEnCyTypeError(json, error)), maybeRequiredKeyMessage, maybeInvalidKeyMessage).flatten
+      .mkString(". ")
+  }
+
+  private def keysFromErrorMessage(allSameErrors: List[ValidationError], keyword: String): List[String] =
+    allSameErrors
+      .filter(_.keyword == keyword)
+      .map(_.getMessage)
+      .map("\\[.*]".r.findAllIn(_).next().drop(1).dropRight(1))
+
+  private def constructEnCyTypeError(json: Json, error: ValidationError): String = {
+    val errorProperty: String = error.location.split("/").last
+    val errorLocation: String =
+      tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = true)
+
+    val errorMessage: String =
+      s"Property $errorProperty Expected type String or JSONObject with structure {en: String} or {en: String, cy: String}"
+    constructCustomErrorMessage(errorLocation, errorMessage)
+  }
+
+  private def parseNormalTypeError(
+    schema: Json,
+    json: Json,
+    error: ValidationError,
+    errors: NonEmptyList[ValidationError]
+  ): String = {
+    val maybeSchemaError: List[Option[String]] = errors
+      .filter(_.location == error.location)
+      .map(_.schemaLocation)
+      .filter(_.isDefined)
+      .distinct
+
+    maybeSchemaError match {
+      case maybeSchemaLocation :: Nil =>
+        maybeSchemaLocation match {
+          case Some(schemaLocation) =>
+            generateNormalTypeErrorMessage(schema, json, error, errors, schemaLocation)
+          case None => error.getMessage
+        }
+      case _ => error.getMessage
+    }
+  }
+
+  private def generateNormalTypeErrorMessage(
+    schema: Json,
+    json: Json,
+    error: ValidationError,
+    errors: NonEmptyList[ValidationError],
+    schemaLocation: String
+  ): String = {
+    val errorProperty: String = error.location.split("/").last
+    val errorLocation: String =
+      tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = true)
+
+    errors.filter(_.location == error.location).filter(_.keyword == "type").map(_.getMessage) match {
+      case Nil => error.getMessage
+      case errorMessage :: Nil =>
+        val typeFound: String = errorMessage.split(" ").last
+        constructNormalTypeErrorMessage(schema, schemaLocation, error, errorLocation, errorProperty, typeFound)
+      case _ => error.getMessage
+    }
+  }
+
+  private def constructNormalTypeErrorMessage(
+    schema: Json,
+    schemaLocation: String,
+    error: ValidationError,
+    errorLocation: String,
+    errorProperty: String,
+    typeFound: String
+  ): String =
+    goDownSchema(schema, schemaLocation.split("/").toList.tail ++ List("type")) match {
+      case Left(_) => error.getMessage
+
+      case Right(requiredType) =>
+        val maybeRequiredType: Option[String] = if (requiredType.isArray) {
+          requiredType.as[List[String]].map(_.mkString(", ")).toOption
+        } else if (requiredType.isString) {
+          requiredType.asString
+        } else {
+          None
+        }
+
+        maybeRequiredType match {
+          case Some(value) =>
+            val errorMessage: String =
+              s"Property $errorProperty expected type [${value.capitalize}], found [$typeFound]"
+            constructCustomErrorMessage(errorLocation, errorMessage)
+          case None => error.getMessage
+        }
+    }
+}

--- a/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
@@ -133,8 +133,8 @@ object JsonSchemeErrorParser {
         schema.hcursor
           .downField(current)
           .as[Json] match {
-          case Left(decodingFailure)  => Left(decodingFailure)
-          case Right(reducedSchema) => goDownSchema(reducedSchema, next)
+          case Left(decodingFailure) => Left(decodingFailure)
+          case Right(reducedSchema)  => goDownSchema(reducedSchema, next)
         }
     }
 

--- a/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
@@ -218,7 +218,7 @@ object JsonSchemeErrorParser {
       tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = true)
 
     val errorMessage: String =
-      s"Property $errorProperty Expected type String or JSONObject with structure {en: String} or {en: String, cy: String}"
+      s"Property $errorProperty expected type String or JSONObject with structure {en: String} or {en: String, cy: String}"
     constructCustomErrorMessage(errorLocation, errorMessage)
   }
 

--- a/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
@@ -133,8 +133,8 @@ object JsonSchemeErrorParser {
         schema.hcursor
           .downField(current)
           .as[Json] match {
-          case Left(value)  => Left(value)
-          case Right(value) => goDownSchema(value, next)
+          case Left(decodingFailure)  => Left(decodingFailure)
+          case Right(reducedSchema) => goDownSchema(reducedSchema, next)
         }
     }
 
@@ -149,9 +149,9 @@ object JsonSchemeErrorParser {
       case Right(requirements: Json) =>
         requirements.as[Map[String, Map[String, String]]] match {
           case Left(_) => error.getMessage
-          case Right(value) =>
+          case Right(propertyAndPattern) =>
             val errorMessage: String =
-              s"Property $property can only be used with ${requiredPropertyValuesFromPattern(value)}"
+              s"Property $property can only be used with ${requiredPropertyValuesFromPattern(propertyAndPattern)}"
             constructCustomErrorMessage(errorLocation, errorMessage)
         }
     }
@@ -286,9 +286,9 @@ object JsonSchemeErrorParser {
         }
 
         maybeRequiredType match {
-          case Some(value) =>
+          case Some(requiredType) =>
             val errorMessage: String =
-              s"Property $errorProperty expected type [${value.capitalize}], found [$typeFound]"
+              s"Property $errorProperty expected type [${requiredType.capitalize}], found [$typeFound]"
             constructCustomErrorMessage(errorLocation, errorMessage)
           case None => error.getMessage
         }

--- a/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidator.scala
@@ -16,15 +16,12 @@
 
 package uk.gov.hmrc.gform.formtemplate
 
-import cats.data.{ NonEmptyList, ValidatedNel }
-import io.circe.Decoder.Result
-import io.circe.{ DecodingFailure, Json }
+import cats.data.ValidatedNel
+import io.circe.Json
 import io.circe.jawn.JawnParser
 import io.circe.schema.Schema
 import io.circe.schema.ValidationError
 import uk.gov.hmrc.gform.exceptions.SchemaValidationException
-
-import scala.annotation.tailrec
 
 object JsonSchemeValidator {
 
@@ -48,168 +45,7 @@ object JsonSchemeValidator {
         val validated: ValidatedNel[ValidationError, Unit] = formTemplateSchema.validate(json)
 
         validated.leftMap { errors =>
-          val fullError: NonEmptyList[String] = {
-            val errorsWithParsedTypeErrors = parseTypeErrors(errors, json)
-
-            maybeFirstSchemaValidationErrorIndex(errors) match {
-              case None => errorsWithParsedTypeErrors.map(_.getMessage)
-              case Some(firstDependencyIndex) =>
-                val conditionalValidationErrors: List[String] =
-                  parseConditionalValidationErrors(errors, firstDependencyIndex, schema, json)
-
-                constructFullError(errorsWithParsedTypeErrors, conditionalValidationErrors, firstDependencyIndex)
-            }
-          }
-
-          SchemaValidationException(fullError)
+          JsonSchemeErrorParser.parseErrorMessages(errors, schema, json)
         }.toEither
     }
-
-  private def parseTypeErrors(
-    errors: NonEmptyList[ValidationError],
-    json: Json
-  ): NonEmptyList[ValidationError] =
-    errors.map { error =>
-      if (error.keyword == "type") {
-        val errorProperty = error.location.split("/").last
-        val errorLocationId: String = tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = true)
-        val errorMessage =
-          s"Error at ID <$errorLocationId>: Property $errorProperty ${error.getMessage.split(":").tail.mkString(":").strip()}"
-
-        ValidationError(error.keyword, errorMessage, error.location, error.schemaLocation)
-      } else {
-        error
-      }
-    }
-
-  private def maybeFirstSchemaValidationErrorIndex(errors: NonEmptyList[ValidationError]): Option[Int] = errors
-    .map(_.schemaLocation.getOrElse(""))
-    .toList
-    .zipWithIndex
-    .collectFirst { case (lookup, index) if lookup.contains("dependencies") => index }
-
-  private def parseConditionalValidationErrors(
-    errors: NonEmptyList[ValidationError],
-    firstDependencyIndex: Int,
-    schema: Json,
-    json: Json
-  ): List[String] =
-    getErrorLocationsAndProperties(errors, firstDependencyIndex).distinct.map { case (location, property) =>
-      val errorLocation = tryConvertErrorLocationToId(json, location, propertyNameInLocation = false)
-
-      val maybeRequirements: Either[DecodingFailure, String] =
-        propertyRequirementsFromSchema(schema, property).map(requiredPropertyValuesFromPattern)
-
-      maybeRequirements match {
-        case Left(_) => s"$errorLocation: Could not find validation in the schema for property: $property"
-        case Right(requirements) =>
-          s"Error at ID <$errorLocation>: Property $property can only be used with $requirements"
-      }
-    }
-
-  private def getErrorLocationsAndProperties(
-    errors: NonEmptyList[ValidationError],
-    firstDependencyIndex: Int
-  ): List[(String, String)] =
-    errors.toList.slice(firstDependencyIndex, errors.length).flatMap { error =>
-      error.schemaLocation.flatMap(schemaErrorLocation =>
-        maybeErrorLocationAndPropertyFromKeyword(error, schemaErrorLocation.split("/"))
-      )
-    }
-
-  private def maybeErrorLocationAndPropertyFromKeyword(
-    error: ValidationError,
-    splitErrorLocation: Array[String]
-  ): Option[(String, String)] =
-    error.keyword match {
-      case "pattern" =>
-        Some(
-          (
-            error.location.substring(0, error.location.lastIndexOf("/")),
-            splitErrorLocation(splitErrorLocation.length - 3)
-          )
-        )
-      case "required" =>
-        Some((error.location, splitErrorLocation.last))
-      case _ => None
-    }
-
-  private def tryConvertErrorLocationToId(json: Json, location: String, propertyNameInLocation: Boolean): String = {
-    val errorLocationSections = location.split("/").toList.tail
-    val errorLocationSectionsWithoutProperty =
-      if (propertyNameInLocation) errorLocationSections.dropRight(1) else errorLocationSections
-
-    // If cannot get ID of location, use original location message instead
-    getErrorLocationId(json, errorLocationSectionsWithoutProperty).flatMap(_.asString).getOrElse(location)
-  }
-
-  @tailrec
-  private def getErrorLocationId(json: Json, remainingSections: List[String]): Option[Json] =
-    remainingSections match {
-      // No more sections to traverse, so get ID of current section to return
-      case Nil =>
-        json.hcursor.downField("id").as[Json] match {
-          case Left(_)                => None
-          case Right(errorLocationId) => Some(errorLocationId)
-        }
-
-      // More sections to traverse, so check if current json is a List of Json or a Json
-      case section :: nextRemainingSections =>
-        json.as[List[Json]] match {
-
-          // If Json, go to next section
-          case Left(_) =>
-            json.hcursor.downField(section).as[Json] match {
-              case Left(_)                => None
-              case Right(nextJsonSection) => getErrorLocationId(nextJsonSection, nextRemainingSections)
-            }
-
-          // If List of Json, get Int of next section and index the List to go to next section
-          case Right(jsonList) =>
-            section.toIntOption match {
-              case Some(sectionInt) => getErrorLocationId(jsonList(sectionInt), nextRemainingSections)
-              case None             => None
-            }
-        }
-    }
-
-  private def propertyRequirementsFromSchema(schema: Json, property: String): Result[Map[String, Map[String, String]]] =
-    schema.hcursor
-      .downField("$defs")
-      .downField("fields")
-      .downField("dependencies")
-      .downField(property)
-      .downField("properties")
-      .as[Map[String, Map[String, String]]]
-
-  private def requiredPropertyValuesFromPattern(requiredPropertyAndPattern: Map[String, Map[String, String]]): String =
-    requiredPropertyAndPattern.view
-      .mapValues { requiredPattern =>
-        requiredPattern.values
-          .map { requiredValues =>
-            requiredValues.substring(1, requiredValues.length - 1).replace("|", ", ")
-          }
-          .mkString(", ")
-      }
-      .map { case (requiredProperty, requiredValues) =>
-        if (requiredValues.contains("?!")) {
-          s"$requiredProperty not: [${requiredValues.substring(4, requiredValues.length - 4)}]"
-        } else {
-          s"$requiredProperty: [$requiredValues]"
-        }
-      }
-      .mkString(", ")
-
-  private def constructFullError(
-    baseErrors: NonEmptyList[ValidationError],
-    conditionalValidationErrors: List[String],
-    firstDependencyIndex: Int
-  ) =
-    // Using unsafe because errors is an NEL and firstDependencyIndex is not None in this branch
-    NonEmptyList.fromListUnsafe(
-      baseErrors
-        .map(_.getMessage)
-        .toList
-        .slice(0, firstDependencyIndex) ++ conditionalValidationErrors
-    )
 }

--- a/conf/formTemplateSchema.json
+++ b/conf/formTemplateSchema.json
@@ -5,10 +5,7 @@
   "type": "object",
   "patternProperties": {
     "^(comment)": {
-      "type": [
-        "string",
-        "object"
-      ]
+      "$ref": "#/$defs/stringOrEnCyObject"
     },
     "^(_)": {
       "type": [
@@ -27,16 +24,10 @@
       "pattern": "^[a-zA-Z0-9-]+$"
     },
     "formName": {
-      "type": [
-        "string",
-        "object"
-      ]
+      "$ref": "#/$defs/stringOrEnCyObject"
     },
     "description": {
-      "type": [
-        "string",
-        "object"
-      ]
+      "$ref": "#/$defs/stringOrEnCyObject"
     },
     "formCategory": {
       "type": "string",
@@ -84,19 +75,13 @@
       "pattern": "^(false)$"
     },
     "save4LaterInfoText": {
-      "type": [
-        "string",
-        "object"
-      ]
+      "$ref": "#/$defs/stringOrEnCyObject"
     },
     "note": {
       "type": "string"
     },
     "emailTemplateId": {
-      "type": [
-        "string",
-        "object"
-      ]
+      "$ref": "#/$defs/stringOrEnCyObject"
     },
     "emailParameters": {
       "type": "array",
@@ -180,10 +165,7 @@
           "type": "array"
         },
         "exitMessage": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         }
       }
     },
@@ -217,22 +199,13 @@
           "type": "object"
         },
         "ivFailure": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "notAllowedIn": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "minimumCL": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         }
       }
     },
@@ -273,10 +246,7 @@
       "type": "object",
       "patternProperties": {
         "^(comment)": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "^(_)": {
           "type": [
@@ -294,38 +264,23 @@
           "type": "string"
         },
         "caption": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "displayWidth": {
           "type": "string",
           "pattern": "^(m|l|xl)$"
         },
         "title": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "description": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "shortName": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "noPIITitle": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "includeIf": {
           "type": "string"
@@ -337,10 +292,7 @@
           "type": "string"
         },
         "continueLabel": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "presentationHint": {
           "type": "string",
@@ -359,16 +311,10 @@
           "type": "array"
         },
         "summaryName": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "summaryDescription": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "addAnotherQuestion": {
           "type": "object"
@@ -411,10 +357,7 @@
             "additionalProperties": false,
             "properties": {
               "title": {
-                "type": [
-                  "string",
-                  "object"
-                ]
+                "$ref": "#/$defs/stringOrEnCyObject"
               },
               "includeIf": {
                 "type": "string"
@@ -454,10 +397,7 @@
       "type": "object",
       "patternProperties": {
         "^(comment)": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "^(_)": {
           "type": [
@@ -481,22 +421,13 @@
           "type": "string"
         },
         "label": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "shortName": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "helpText": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "includeIf": {
           "type": "string"
@@ -523,22 +454,13 @@
           "pattern": "^(false|true|no|yes)$"
         },
         "errorMessage": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "errorShortName": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "errorShortNameStart": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "displayWidth": {
           "type": "string"
@@ -615,10 +537,7 @@
           "type": "array"
         },
         "infoText": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "infoType": {
           "type": "string"
@@ -654,49 +573,28 @@
           "type": "integer"
         },
         "repeatLabel": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "repeatAddAnotherText": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "noneChoiceError": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "dividerText": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "summaryValue": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "header": {
           "type": "array"
         },
         "chooseAddressLabel": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "confirmAddressLabel": {
-          "type": [
-            "string",
-            "object"
-          ]
+          "$ref": "#/$defs/stringOrEnCyObject"
         },
         "international": {
           "type": "string"
@@ -980,6 +878,22 @@
           }
         }
       }
+    },
+    "stringOrEnCyObject": {
+      "type": [
+        "string",
+        "object"
+      ],
+      "properties": {
+        "en": {
+          "type": "string"
+        },
+        "cy": {
+          "type": "string"
+        }
+      },
+      "required": ["en"],
+      "additionalProperties": false
     }
   }
 }

--- a/test/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidatorSpec.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidatorSpec.scala
@@ -1333,7 +1333,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at <#/description>: Property description expected type String or JSONObject with structure {en: String} or {en: String, cy: String}",
+      "Error at <#/description>: Property description expected type String or JSONObject with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1370,7 +1370,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
 
     val expectedResult = List(
       "Error at <#/description>: Property description expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required",
-      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [value] are not permitted",
+      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [value] are not permitted"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1394,7 +1394,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [value] are not permitted",
+      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [value] are not permitted"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1419,7 +1419,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [value, anotherValue] are not permitted",
+      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [value, anotherValue] are not permitted"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1443,7 +1443,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required",
+      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1465,7 +1465,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required",
+      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1500,7 +1500,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
 
     val expectedResult = List(
       "Error at ID <TestID1>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [xyz] are not permitted",
-      "Error at ID <TestID2>: Property shortName expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required",
+      "Error at ID <TestID2>: Property shortName expected type String or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -1522,7 +1522,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId>: Property label expected type String or JSONObject with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)

--- a/test/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidatorSpec.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidatorSpec.scala
@@ -1275,7 +1275,6 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val jsonTemplate = constructTestOneSectionJsonTemplate(testProperties)
 
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
-    println(result)
 
     val expectedResult = List(
       "Error at ID <testId>: Property dataThreshold can only be used with type: [text], multiline: [true]",


### PR DESCRIPTION
Adds the relevant schema check.
Refactors error message parsing to work with new schema.
Gets error location field IDs if possible and if not, still parse into custom error message.