### PR TITLE
GFORMS-2586: Add Schema Validation for summarySection (Main and Task List) Properties

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/JsonSchemeErrorParser.scala
@@ -34,6 +34,12 @@ object JsonSchemeErrorParser {
           parseConditionalValidationErrorMessage(schema, json, error)
         } else if (errors.filter(_.location === error.location).map(_.keyword).contains("type")) {
           parseTypeError(error, errors, json, schema)
+        } else if (error.keyword === "required") {
+          parseRequiredError(schema, json, error)
+        } else if (error.keyword === "pattern") {
+          parsePatternError(schema, json, error)
+        } else if (error.keyword === "additionalProperties") {
+          parseAdditionalPropertiesError(errors, json, error)
         } else {
           error.getMessage
         }
@@ -42,6 +48,89 @@ object JsonSchemeErrorParser {
     }
 
     SchemaValidationException(parsedErrors.map(_.getMessage).distinct)
+  }
+
+  private def parseRequiredError(schema: Json, json: Json, error: ValidationError): String = {
+    val errorLocation: String = tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = true)
+
+    val maybeRequirements: Either[DecodingFailure, Json] =
+      goDownSchema(
+        schema,
+        error.schemaLocation.getOrElse("").split("/").tail.toList ++ List("required")
+      )
+
+    val property: String = error.schemaLocation
+      .getOrElse("")
+      .split("/")
+      .last
+
+    maybeRequirements match {
+      case Left(_) => error.getMessage
+      case Right(requirementsJson) =>
+        requirementsJson.as[List[String]] match {
+          case Left(_) => error.getMessage
+          case Right(requirements) =>
+            val errorMessage = s"$property requires properties [${requirements.mkString(", ")}] to be present"
+            constructCustomErrorMessage(errorLocation, errorMessage)
+        }
+    }
+  }
+
+  private def parsePatternError(schema: Json, json: Json, error: ValidationError): String = {
+    val errorLocation: String = tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = false)
+
+    val maybeRequirements: Either[DecodingFailure, Json] =
+      goDownSchema(
+        schema,
+        error.schemaLocation.getOrElse("").split("/").tail.toList ++ List("pattern")
+      )
+
+    val property: String = error.schemaLocation
+      .getOrElse("")
+      .split("/")
+      .last
+
+    maybeRequirements match {
+      case Left(_) => error.getMessage
+      case Right(requirementsJson) =>
+        requirementsJson.asString match {
+          case None => error.getMessage
+          case Some(requiredValues) =>
+            val notMatchingPattern: Boolean = requiredValues.contains("?!")
+            val lengthOfTrim: Int = if (notMatchingPattern) 5 else 2
+
+            val parsedRequiredValues: String =
+              requiredValues.substring(lengthOfTrim, requiredValues.length - lengthOfTrim).replace("|", ", ")
+
+            val errorMessage: String =
+              s"Property $property expected value ${if (notMatchingPattern) "not " else ""}[$parsedRequiredValues]"
+
+            constructCustomErrorMessage(errorLocation, errorMessage)
+        }
+    }
+  }
+
+  private def parseAdditionalPropertiesError(
+    errors: NonEmptyList[ValidationError],
+    json: Json,
+    error: ValidationError
+  ): String = {
+    val errorLocation: String = tryConvertErrorLocationToId(json, error.location, propertyNameInLocation = false)
+    val allSameErrors = errors.filter(_.location === error.location).filter(_.keyword === error.keyword)
+
+    val property: String = error.schemaLocation
+      .getOrElse("")
+      .split("/")
+      .last
+
+    val allInvalidProperties = allSameErrors
+      .map(_.getMessage)
+      .map("\\[.*]".r.findAllIn(_).next())
+      .map(property => property.substring(1, property.length - 1))
+      .mkString(", ")
+
+    val errorMessage = s"$property has invalid key(s) [$allInvalidProperties]"
+    constructCustomErrorMessage(errorLocation, errorMessage)
   }
 
   private def parseConditionalValidationErrorMessage(schema: Json, json: Json, error: ValidationError): String =
@@ -197,13 +286,13 @@ object JsonSchemeErrorParser {
       .mapValues { requiredPattern =>
         requiredPattern.values
           .map { requiredValues =>
-            requiredValues.substring(1, requiredValues.length - 1).replace("|", ", ")
+            requiredValues.substring(2, requiredValues.length - 2).replace("|", ", ")
           }
           .mkString(", ")
       }
       .map { case (requiredProperty, requiredValues) =>
         if (requiredValues.contains("?!")) {
-          s"$requiredProperty not: [${requiredValues.substring(4, requiredValues.length - 4)}]"
+          s"$requiredProperty not: [${requiredValues.substring(3, requiredValues.length - 3)}]"
         } else {
           s"$requiredProperty: [$requiredValues]"
         }

--- a/conf/formTemplateSchema.json
+++ b/conf/formTemplateSchema.json
@@ -688,7 +688,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^info$"
+              "pattern": "^(info)$"
             }
           }
         },
@@ -698,7 +698,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^info$"
+              "pattern": "^(info)$"
             }
           }
         },
@@ -708,7 +708,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -718,7 +718,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -728,7 +728,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -738,7 +738,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -748,7 +748,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -758,7 +758,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -768,7 +768,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -778,7 +778,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^choice|revealingChoice$"
+              "pattern": "^(choice|revealingChoice)$"
             }
           }
         },
@@ -789,10 +789,10 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^text$"
+              "pattern": "^(text)$"
             },
             "multiline": {
-              "pattern": "^true$"
+              "pattern": "^(true)$"
             }
           }
         },
@@ -803,10 +803,10 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^text$"
+              "pattern": "^(text)$"
             },
             "multiline": {
-              "pattern": "^true$"
+              "pattern": "^(true)$"
             }
           }
         },
@@ -816,7 +816,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^text|choice|date|group$"
+              "pattern": "^(text|choice|date|group)$"
             }
           }
         },
@@ -826,7 +826,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^address|overseasAddress$"
+              "pattern": "^(address|overseasAddress)$"
             }
           }
         },
@@ -836,7 +836,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^address$"
+              "pattern": "^(address)$"
             }
           }
         },
@@ -846,7 +846,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^address$"
+              "pattern": "^(address)$"
             }
           }
         },
@@ -856,7 +856,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^overseasAddress$"
+              "pattern": "^(overseasAddress)$"
             }
           }
         },
@@ -866,7 +866,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^overseasAddress$"
+              "pattern": "^(overseasAddress)$"
             }
           }
         },
@@ -876,7 +876,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^overseasAddress$"
+              "pattern": "^(overseasAddress)$"
             }
           }
         },
@@ -886,7 +886,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^overseasAddress$"
+              "pattern": "^(overseasAddress)$"
             }
           }
         },
@@ -896,7 +896,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^overseasAddress$"
+              "pattern": "^(overseasAddress)$"
             }
           }
         },
@@ -906,7 +906,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^postcodeLookup$"
+              "pattern": "^(postcodeLookup)$"
             }
           }
         },
@@ -916,7 +916,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^postcodeLookup$"
+              "pattern": "^(postcodeLookup)$"
             }
           }
         },
@@ -926,7 +926,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^text$"
+              "pattern": "^(text)$"
             },
             "format": {
               "pattern": "^((?!sterling|positiveSterling|positiveWholeSterling).)*$"
@@ -939,7 +939,7 @@
           ],
           "properties": {
             "type": {
-              "pattern": "^table$"
+              "pattern": "^(table)$"
             }
           }
         }

--- a/conf/formTemplateSchema.json
+++ b/conf/formTemplateSchema.json
@@ -223,7 +223,40 @@
       "type": "object"
     },
     "summarySection": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "header",
+        "footer"
+      ],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/stringOrEnCyObject"
+        },
+        "header": {
+          "$ref": "#/$defs/stringOrEnCyObject"
+        },
+        "footer": {
+          "$ref": "#/$defs/stringOrEnCyObject"
+        },
+        "displayWidth": {
+          "type": "string",
+          "pattern": "^(m|l|xl)$"
+        },
+        "continueLabel": {
+          "$ref": "#/$defs/stringOrEnCyObject"
+        },
+        "pdf": {
+          "type": "object"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/fields"
+          }
+        }
+      }
     },
     "declarationSection": {
       "type": "object"
@@ -363,7 +396,40 @@
                 "type": "string"
               },
               "summarySection": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "title",
+                  "header",
+                  "footer"
+                ],
+                "properties": {
+                  "title": {
+                    "$ref": "#/$defs/stringOrEnCyObject"
+                  },
+                  "header": {
+                    "$ref": "#/$defs/stringOrEnCyObject"
+                  },
+                  "footer": {
+                    "$ref": "#/$defs/stringOrEnCyObject"
+                  },
+                  "displayWidth": {
+                    "type": "string",
+                    "pattern": "^(m|l|xl)$"
+                  },
+                  "includeIf": {
+                    "type": "string"
+                  },
+                  "continueLabel": {
+                    "$ref": "#/$defs/stringOrEnCyObject"
+                  },
+                  "fields": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/fields"
+                    }
+                  }
+                }
               },
               "declarationSection": {
                 "type": "object"
@@ -477,7 +543,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["en"],
+                "required": [
+                  "en"
+                ],
                 "additionalProperties": false
               }
             }
@@ -640,7 +708,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["en"],
+                "required": [
+                  "en"
+                ],
                 "additionalProperties": false
               }
             }
@@ -958,7 +1028,9 @@
           "type": "string"
         }
       },
-      "required": ["en"],
+      "required": [
+        "en"
+      ],
       "additionalProperties": false
     }
   }

--- a/test/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidatorSpec.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/JsonSchemeValidatorSpec.scala
@@ -2060,8 +2060,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}",
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2088,8 +2088,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}",
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2116,8 +2116,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}",
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2149,8 +2149,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}. Invalid key(s) [val] are not permitted",
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}. Invalid key(s) [val] are not permitted",
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2182,8 +2182,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required",
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required",
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2214,8 +2214,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [xyz] are not permitted",
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required. Invalid key(s) [xyz] are not permitted",
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2247,8 +2247,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}. Invalid key(s) [xyz] are not permitted",
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required"
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}. Invalid key(s) [xyz] are not permitted",
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}. Missing key(s) [en] are required"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2281,8 +2281,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
 
     val expectedResult = List(
       "Error at ID <testId: header/0>: Property cy expected type [String], found [Boolean]",
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}",
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}"
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}"
     )
 
     runInvalidJsonTest(result, expectedResult)
@@ -2312,8 +2312,8 @@ class JsonSchemeValidatorSpec extends FunSuite {
     val result = JsonSchemeValidator.validateJson(jsonTemplate)
 
     val expectedResult = List(
-      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}",
-      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObject with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId: header/0>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}",
+      "Error at ID <testId: header/1>: Property header expected type Array of either Strings or JSONObjects with structure {en: String} or {en: String, cy: String}",
       "Error at ID <testId: header/0>: Property cy expected type [String], found [Boolean]"
     )
 
@@ -2918,7 +2918,7 @@ class JsonSchemeValidatorSpec extends FunSuite {
   }
 
   test(
-    "validateJson accepts the form when a choices property is an Array of one Object with the En and Cy properties, and one Object with just the En property"
+    "validateJson accepts the form when a header property is an Array of one Object with the En and Cy properties, and one Object with just the En property"
   ) {
     val testProperties =
       json"""


### PR DESCRIPTION
Adds schema validation for summarySections.

Adds functionality to find lowest level field ID in the case of nested fields.

Fixes bug where some patterns in the schema would only match on the start of the word, meaning invalid fields would pass the schema validation if they started with the matched characters but had additional characters afterwards.