### PR TITLE
GFORMS-3145 - Issue with Substring -f you use substring() inside an e…

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/BooleanExprSubstituter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/BooleanExprSubstituter.scala
@@ -61,14 +61,14 @@ object BooleanExprSubstituter extends Substituter[BooleanExprSubstitutions, Form
         case IndexOfDataRetrieveCtx(_, _)  => t
         case NumberedList(_)               => t
         case BulletedList(_)               => t
-        case StringOps(_, _)               => t
+        case StringOps(expr, fn)           => StringOps(substitute(substitutions, expr), fn)
         case Concat(exprs)                 => Concat(exprs.map(substitute(substitutions, _)))
         case CountryOfItmpAddress          => t
         case ChoicesRevealedField(_)       => t
         case ChoicesSelected(_)            => t
         case ChoicesAvailable(_)           => t
         case TaskStatus(_)                 => t
-        case LookupOps(_, _)               => t
+        case LookupOps(expr, fn)           => LookupOps(substitute(substitutions, expr), fn)
       }
     }
 

--- a/app/uk/gov/hmrc/gform/formtemplate/ExprSubstituter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/ExprSubstituter.scala
@@ -70,7 +70,7 @@ object ExprSubstituter extends Substituter[ExprSubstitutions, FormTemplate] {
         case ChoicesSelected(_)              => t
         case ChoicesAvailable(_)             => t
         case TaskStatus(_)                   => t
-        case LookupOps(_, _)                 => t
+        case LookupOps(expr, fn)             => LookupOps(substitute(substitutions, expr), fn)
       }
     }
 

--- a/app/uk/gov/hmrc/gform/formtemplate/TopLevelExpressions.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/TopLevelExpressions.scala
@@ -188,14 +188,14 @@ object TopLevelExpressions {
         case IndexOfDataRetrieveCtx(_, _)  => e
         case NumberedList(_)               => e
         case BulletedList(_)               => e
-        case StringOps(_, _)               => e
+        case StringOps(expr, fn)           => StringOps(loop(expr), fn)
         case Concat(exprs)                 => Concat(exprs.map(loop))
         case CountryOfItmpAddress          => e
         case ChoicesRevealedField(_)       => e
         case ChoicesSelected(_)            => e
         case ChoicesAvailable(_)           => e
         case TaskStatus(_)                 => e
-        case LookupOps(_, _)               => e
+        case LookupOps(expr, fn)           => LookupOps(loop(expr), fn)
       }
     expressions.get(expressionId).fold(expressions) { expr =>
       expressions + (expressionId -> loop(expr))


### PR DESCRIPTION
…xpression using and expression.

{
  "_id": "substring-example",
  "formName": "Service name",
  "description": "",
  "version": 1,
  "authConfig": {
    "authModule": "anonymous"
  },
  "expressions":  {
    "organisationPersonType": "'a'",
    "orgPersonArticle": "if (substring(organisationPersonType,0,1) = 'a' || substring(organisationPersonType,0,1) = 'e' || substring(organisationPersonType,0,1) = 'i'  || substring(organisationPersonType,0,1) = 'o' || substring(organisationPersonType,0,1) = 'u') then 'an' else 'a' "
  },
  "sections": [
    {
      "title": "title",
      "fields": [
        {
          "id": "proof",
          "type": "file",
          "helpText": "${orgPersonArticle}"
        }
      ]
    }
  ],
  "declarationSection": {
    "title": "Declaration",
    "shortName": "Declaration",
    "fields": []
  },
  "acknowledgementSection": {
    "title": "Acknowledgement",
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}