### PR TITLE
GFORMS-3140 - The includeIf for a title or other property can contain…

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateValidator.scala
@@ -327,7 +327,8 @@ object FormTemplateValidator {
   ): ValidationResult = {
     val invalidResults: List[ValidationResult] = allExpressions.flatMap(_.referenceInfos) collect {
       case FormCtxExpr(path, FormCtx(fcId))
-          if path.subpaths.contains("errorMessage") && !noPIIFcIds(formTemplate).contains(fcId) =>
+          if path.subpaths.contains("errorMessage") && !noPIIFcIds(formTemplate).contains(fcId) &&
+            !path.subpaths.lastOption.exists(_ === "includeIf") =>
         Invalid(s"""${path.path} contains PII fcId: ${fcId.value}""")
     }
     Monoid.combineAll(invalidResults)


### PR DESCRIPTION
… fields that do not exist in the form
```
{
  "_id": "smart-string-include-if-pii",
  "formName": "Service name",
  "description": "",
  "version": 1,
  "authConfig": {
    "authModule": "anonymous"
  },
  "sections": [
    {
      "title": "How often do you send your VAT returns?",
      "fields": [
        {
          "id": "period",
          "type": "choice",
          "shortName": "VAT periods",
          "choices": [
            "Quarterly",
            "Annually"
          ]
        }
      ]
    },
    {
      "title": "Section 2",
      "fields": [
        {
          "id": "text2",
          "type": "text",
          "format": "text",
          "errorMessage": [
            {
              "en": "Quarterly turnover must be greater than zero",
              "includeIf": "${period contains 0}"
            },
            {
              "en": "Annual turnover must be greater than zero"
            }
          ]
        }
      ]
    }
  ],
  "declarationSection": {
    "title": "Declaration",
    "shortName": "Declaration",
    "fields": []
  },
  "acknowledgementSection": {
    "title": "Acknowledgement",
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}
```