### PR TITLE
GFORMS-3166 - Substitute top level expression in match function

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/ExprSubstituter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/ExprSubstituter.scala
@@ -128,7 +128,7 @@ object ExprSubstituter extends Substituter[ExprSubstitutions, FormTemplate] {
         case Contains(multiValueField, value) => Contains(multiValueField, value(substitutions))
         case In(value, dataSource)            => In(value(substitutions), dataSource)
         case h @ HasAnswer(value, dataSource) => h
-        case m @ MatchRegex(expr, regex)      => m
+        case MatchRegex(expr, regex)          => MatchRegex(expr(substitutions), regex)
         case DateBefore(l, r)                 => DateBefore(l(substitutions), r(substitutions))
         case DateAfter(l, r)                  => DateAfter(l(substitutions), r(substitutions))
         case f @ FormPhase(value)             => f


### PR DESCRIPTION
```
{
  "_id": "top-level-expression-with-match",
  "formName": "Top level with match",
  "version": 1,
  "description": "",
  "authConfig": {
    "authModule": "anonymous"
  },
  "expressions": {
    "check": "if (1 = 1) then 'foo' else 'bar'"
  },
  "sections": [
    {
      "title": "Hello A",
      "fields": [
        {
          "id": "testA",
          "type": "text",
          "format": "text",
          "label": "Test A"
        },
        {
          "id": "testB",
          "includeIf": "${check match 'foo'}",
          "type": "text",
          "format": "text",
          "label": "Test B"
        }
      ]
    }
  ],
  "declarationSection": {
    "title": "Declaration",
    "fields": []
  },
  "acknowledgementSection": {
    "title": "Confirmation page",
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}
```