### PR TITLE
GFORMS-3274 - Fix issue in computation of expressionOutput

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/BooleanExprSubstituter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/BooleanExprSubstituter.scala
@@ -22,7 +22,7 @@ object BooleanExprSubstituter extends Substituter[BooleanExprSubstitutions, Form
 
   import uk.gov.hmrc.gform.formtemplate.Substituter.SubstituterSyntax
 
-  implicit val exprSubstituter: Substituter[BooleanExprSubstitutions, Expr] =
+  implicit val booleanExprSubstituterForExpr: Substituter[BooleanExprSubstitutions, Expr] =
     new Substituter[BooleanExprSubstitutions, Expr] {
       def substitute(substitutions: BooleanExprSubstitutions, t: Expr): Expr = t match {
         case Else(l, r)            => Else(substitute(substitutions, l), substitute(substitutions, r))

--- a/app/uk/gov/hmrc/gform/formtemplate/ExprSubstituter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/ExprSubstituter.scala
@@ -142,9 +142,6 @@ object ExprSubstituter extends Substituter[ExprSubstitutions, FormTemplate] {
 
   def substitute(substitutions: ExprSubstitutions, t: FormTemplate): FormTemplate =
     implicitly[Substituter[ExprSubstitutions, FormTemplate]].substitute(substitutions, t)
-
-  def substituteExpr(substitutions: ExprSubstitutions, t: Expr): Expr =
-    implicitly[Substituter[ExprSubstitutions, Expr]].substitute(substitutions, t)
 }
 
 trait SubstituteExpressions {

--- a/app/uk/gov/hmrc/gform/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/gform/testonly/TestOnlyController.scala
@@ -31,7 +31,6 @@ import uk.gov.hmrc.gform.core.FOpt
 import uk.gov.hmrc.gform.des.DesAlgebra
 import uk.gov.hmrc.gform.exceptions.UnexpectedState
 import uk.gov.hmrc.gform.form.FormAlgebra
-import uk.gov.hmrc.gform.formtemplate.ExprSubstituter
 import uk.gov.hmrc.gform.formtemplate.TopLevelExpressions
 import uk.gov.hmrc.gform.formtemplate.{ BooleanExprId, Substituter }
 import uk.gov.hmrc.gform.formtemplate.{ BooleanExprSubstitutions, ExprSubstitutions, FormTemplateAlgebra, RequestHandlerAlg }
@@ -69,10 +68,13 @@ class TestOnlyController(
 
   private val formTemplatesRepo = new Repo[FormTemplate]("formTemplate", mongoComponent, _._id.value)
 
-  private def substituteExpr(exprSubstitutions: ExprSubstitutions): ExprSubstitutions =
+  private def substituteExpr(exprSubstitutions: ExprSubstitutions): ExprSubstitutions = {
+    import uk.gov.hmrc.gform.formtemplate.ExprSubstituter._
+    val substituter = implicitly[Substituter[ExprSubstitutions, Expr]]
     ExprSubstitutions(exprSubstitutions.expressions.map { case (id, expr) =>
-      id -> ExprSubstituter.substituteExpr(exprSubstitutions, expr)
+      id -> substituter.substitute(exprSubstitutions, expr)
     })
+  }
 
   private def substituteBooleanExprsInExprs(
     booleanExprSubstitutions: BooleanExprSubstitutions,


### PR DESCRIPTION
```
{
  "_id": "expressions-output-with-boolean-expr-reference",
  "version": 1,
  "formName": "Expressions output with booleanExpressions reference",
  "description": "",
  "authConfig": {
    "authModule": "anonymous"
  },
  "expressions": {
    "indieFilmExpenditureTotal": {
      "value": "if indieFilmQualifying then (indieFilmExpenditure - 1000) else 0",
      "type": "sterling"
    }
  },
  "booleanExpressions": {
    "indieFilmQualifying": "indieFilmExpenditure > 1000"
  },
  "expressionsOutput": [
    "indieFilmExpenditureTotal"
  ],
  "sections": [
    {
      "type": "addToList",
      "title": "Expenditures you have added",
      "summaryName": "Expenditures",
      "shortName": "Expenditure $n",
      "description": "**$n. expenditure",
      "summaryDescription": "Expenditures ${indieFilmExpenditureTotal}",
      "addAnotherQuestion": {
        "id": "expenditure",
        "type": "choice",
        "label": "Do you want to add another expenditure?",
        "format": "yesno"
      },
      "pages": [
        {
          "title": "Indie film expenditure.",
          "fields": [
            {
              "id": "indieFilmExpenditure",
              "label": "What is the total expenditure to date?",
              "helpText": "Enter in GBP.",
              "type": "text",
              "format": "positiveSterling"
            }
          ]
        }
      ]
    }
  ],
  "declarationSection": {
    "shortName": "Declaration",
    "title": "Declaration",
    "fields": []
  },
  "acknowledgementSection": {
    "title": "Acknowledgement Page",
    "fields": []
  },
  "destinations": [
    {
      "id": "eeittReturnApi",
      "type": "handlebarsHttpApi",
      "failOnError": false,
      "profile": "des",
      "convertSingleQuotes": true,
      "uri": "cross-regime/return/APD/eeits/{{APDReg}}",
      "method": "POST",
      "payload": " { 'total': '{{indieFilmExpenditureTotal}}' }}"
    }
  ]
}
```