### PR TITLE
GFORMS-3337 - Button component not pulling through reference from top…

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/Substituter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/Substituter.scala
@@ -273,7 +273,7 @@ object Substituter {
           rows = t.rows(substitutions),
           summaryValue = t.summaryValue(substitutions)
         )
-      case b: Button => b
+      case b: Button => b.copy(reference = b.reference(substitutions), amountInPence = b.amountInPence(substitutions))
     }
 
   implicit def formComponentValidatorSubstituter[A](implicit


### PR DESCRIPTION
… level expression

{
  "_id": "payment-reference-issue",
  "formName": "Name of Service",
  "description": "",
  "version": 1,
  "emailTemplateId": "eeitt_submission_confirmation",
  "authConfig": {
    "authModule": "hmrc"
  },
  "expressions": {
    "paymentRef": "concat('XVC',substring(form.submissionReference,0,4),substring(form.submissionReference,5,9),substring(form.submissionReference,10,14))"
  },
  "sections": [
    {
      "title": {
        "en": "Payment amount",
        "cy": "Pa fath o win sydd dan sylw?"
      },
      "fields": [
        {
          "type": "text",
          "id": "amount",
          "label": {
            "en": "Enter payment amount",
            "cy": "Dewiswch un math o win. Gallwch ddewis rhagor yn nes ymlaen."
          },
          "format": "sterling"
        }
      ]
    }
  ],
  "acknowledgementSection": {
    "title": "Confirmation page",
    "fields": [
      {
        "type": "button",
        "id": "paymentJourney",
        "label": "Pay now",
        "reference": "${paymentRef}",
        "amountInPence": "${amount * 100}",
        "isStartButton": true
      }
    ]
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}