### PR TITLE
GFORMS-3482 - Remove name case object from AuthInfo object

### DIFF
--- a/app/uk/gov/hmrc/gform/core/parsers/ValueParser.scala
+++ b/app/uk/gov/hmrc/gform/core/parsers/ValueParser.scala
@@ -534,7 +534,6 @@ trait ValueParser extends RegexParsers with PackratParsers with BasicParsers {
       | "sautr" ^^^ AuthInfo.SaUtr
       | "ctutr" ^^^ AuthInfo.CtUtr
       | "email" ^^^ AuthInfo.EmailId
-      | "name" ^^^ AuthInfo.Name
       | "itmpName" ~ "." ~ itmpNameFocus ^^ { case _ ~ _ ~ focus =>
         AuthInfo.ItmpNameLens(focus)
       }

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/Expr.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/Expr.scala
@@ -270,7 +270,6 @@ object AuthInfo {
   final case object EmailId extends AuthInfo
   final case object SaUtr extends AuthInfo
   final case object CtUtr extends AuthInfo
-  final case object Name extends AuthInfo
   final case object ItmpName extends AuthInfo
   final case class ItmpNameLens(focus: ItmpNameFocus) extends AuthInfo
   final case object ItmpDateOfBirth extends AuthInfo


### PR DESCRIPTION
Required to support: https://github.com/hmrc/gform-frontend/pull/2514