### PR TITLE
GFORMS-3651 - Destination API submitter token missing. If not defined…

### DIFF
--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
@@ -60,12 +60,10 @@ class HandlebarsHttpApiModule(
     val headers: Seq[(String, String)] = hc.extraHeaders ++ profileConfig.httpHeaders.map {
       case (k, checkToken(v)) => k -> getDynamicHeaderValue(v, envelopeId)
       case (k, v)             => k -> v
-    }.toSeq ++ Seq(
-      "Authorization" ->
-        profileConfig.authorization.fold(
-          hc.authorization.fold("")(_.value)
-        )(_.value)
-    )
+    }.toSeq ++
+      profileConfig.authorization
+        .orElse(hc.authorization)
+        .map(auth => "Authorization" -> auth.value)
 
     val builder = method match {
       case HttpMethod.GET  => wSHttpModule.httpClient.get(url"$fullUrl")


### PR DESCRIPTION
… in the profile config, use the HeaderCarrier auth header