### PR TITLE
GFORMS-3651 - Destination API submitter token missing

### DIFF
--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
@@ -33,7 +33,6 @@ class HandlebarsHttpApiModule(
   configModule: ConfigModule
 )(implicit ec: ExecutionContext) {
 
-  implicit val hc: HeaderCarrier = new HeaderCarrier()
   private val checkToken: Regex = "^\\{(.*)}$".r
   private val dateFormat: Regex = "^dateFormat\\((.*)\\)$".r
 
@@ -52,8 +51,9 @@ class HandlebarsHttpApiModule(
     profile: ProfileName,
     envelopeId: EnvelopeId,
     uri: String,
-    method: HttpMethod
-  )(implicit hc: HeaderCarrier): RequestBuilder = {
+    method: HttpMethod,
+    hc: HeaderCarrier
+  ): RequestBuilder = {
     val profileConfig = configModule.DestinationsServicesConfig()(profile)
     val fullUrl = appendUriSegment(profileConfig.baseUrl, uri)
 
@@ -66,9 +66,9 @@ class HandlebarsHttpApiModule(
         .map(auth => "Authorization" -> auth.value)
 
     val builder = method match {
-      case HttpMethod.GET  => wSHttpModule.httpClient.get(url"$fullUrl")
-      case HttpMethod.POST => wSHttpModule.httpClient.post(url"$fullUrl")
-      case HttpMethod.PUT  => wSHttpModule.httpClient.put(url"$fullUrl")
+      case HttpMethod.GET  => wSHttpModule.httpClient.get(url"$fullUrl")(hc)
+      case HttpMethod.POST => wSHttpModule.httpClient.post(url"$fullUrl")(hc)
+      case HttpMethod.PUT  => wSHttpModule.httpClient.put(url"$fullUrl")(hc)
     }
 
     builder.setHeader(headers: _*)

--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitter.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitter.scala
@@ -38,7 +38,7 @@ trait HandlebarsHttpApiSubmitter {
 }
 
 class RealHandlebarsHttpApiSubmitter(
-  buildRequest: (ProfileName, EnvelopeId, String, HttpMethod) => RequestBuilder,
+  buildRequest: (ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier) => RequestBuilder,
   handlebarsTemplateProcessor: HandlebarsTemplateProcessor = RealHandlebarsTemplateProcessor
 )(implicit ec: ExecutionContext)
     extends HandlebarsHttpApiSubmitter {
@@ -59,7 +59,7 @@ class RealHandlebarsHttpApiSubmitter(
       FocussedHandlebarsModelTree(modelTree),
       TemplateType.Plain
     )
-    val requestBuilder = buildRequest(destination.profile, envelopeId, uri, destination.method)
+    val requestBuilder = buildRequest(destination.profile, envelopeId, uri, destination.method, hc)
 
     val contentType = destination.payloadType match {
       case TemplateType.JSON  => "application/json"
@@ -129,7 +129,7 @@ class RealHandlebarsHttpApiSubmitter(
 
     destination.method match {
       case HttpMethod.GET =>
-        buildRequest(destination.profile, envelopeId, uri, destination.method)
+        buildRequest(destination.profile, envelopeId, uri, destination.method, hc)
           .execute[HttpResponse]
 
       case HttpMethod.POST =>

--- a/test/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitterSpec.scala
+++ b/test/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitterSpec.scala
@@ -50,7 +50,7 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedUri = "test-uri"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -63,7 +63,7 @@ class HandlebarsHttpApiSubmitterSpec
       .anyNumberOfTimes()
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.GET)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.GET, hc)
       .returning(mockRequestBuilder)
       .anyNumberOfTimes()
 
@@ -89,7 +89,7 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedBody = "processed-body"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -105,7 +105,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning(expectedBody)
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc)
       .returning(mockRequestBuilder)
 
     (mockRequestBuilder
@@ -137,7 +137,7 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedUri = "test-uri"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -149,7 +149,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning(expectedUri)
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc)
       .returning(mockRequestBuilder)
 
     (mockRequestBuilder
@@ -183,7 +183,7 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedBody = "processed-body"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -199,7 +199,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning(expectedBody)
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.PUT)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.PUT, hc)
       .returning(mockRequestBuilder)
 
     (mockRequestBuilder
@@ -236,7 +236,7 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedUri = "test-uri"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -256,7 +256,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning("processed2")
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc)
       .returning(mockRequestBuilder)
       .once()
 


### PR DESCRIPTION
fix empty headerCarrier in HandlebarsHttpApiModule buildRequest method