### PR TITLE
GFORMS-3682 - Implement GOV.UK design refresh of page header and footers in gForms

### DIFF
--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplatesControllerRequestHandler.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplatesControllerRequestHandler.scala
@@ -196,6 +196,10 @@ object FormTemplatesControllerRequestHandler {
       (__ \ "displayAccountHeader").json
         .copyFrom((__ \ "displayAccountHeader").json.pick orElse Reads.pure(JsFalse))
 
+    val ensureServiceNavigationComponent =
+      (__ \ "serviceNavigationComponent").json
+        .copyFrom((__ \ "serviceNavigationComponent").json.pick orElse Reads.pure(JsFalse))
+
     val ensureOriginalId = (__ \ "originalId").json.copyFrom((__ \ "_id").json.pick) orElse noTemplateId
 
     val lowerCaseId: Reads[JsObject] = (__ \ "_id").json.copyFrom(
@@ -571,6 +575,7 @@ object FormTemplatesControllerRequestHandler {
         ensureAccessiblePdf and
         ensureDownloadPreviousSubmissionPdf and
         ensureDisplayAccountHeader and
+        ensureServiceNavigationComponent and
         ensureFormCategory and
         ensureLanguages and
         transformSummarySection and

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplate.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplate.scala
@@ -62,7 +62,8 @@ case class FormTemplate(
   displayAccountHeader: Boolean,
   serviceStartPageUrl: Option[ServiceStartPageUrl],
   downloadPreviousSubmissionPdf: Boolean,
-  overrides: Option[Overrides]
+  overrides: Option[Overrides],
+  serviceNavigationComponent: Boolean
 ) {
 
   def formComponents[A](predicate: PartialFunction[FormComponent, A]): List[A] =

--- a/conf/formTemplateSchema.json
+++ b/conf/formTemplateSchema.json
@@ -169,6 +169,10 @@
       "description": "Defines whether the PTA Menu is displayed in the header",
       "type": "boolean"
     },
+    "serviceNavigationComponent": {
+      "description": "Defines whether the Service Navigation Component is used to display the form title",
+      "type": "boolean"
+    },
     "overrides": {
       "type": "object",
       "additionalProperties": false,

--- a/test/resources/templates-to-normalise/choice-in-declaration-section-expected.json
+++ b/test/resources/templates-to-normalise/choice-in-declaration-section-expected.json
@@ -92,5 +92,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/choice-with-dynamic-options-expected.json
+++ b/test/resources/templates-to-normalise/choice-with-dynamic-options-expected.json
@@ -98,5 +98,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/choices-in-group-expected.json
+++ b/test/resources/templates-to-normalise/choices-in-group-expected.json
@@ -120,5 +120,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/exclude-from-pdf-in-summary-section-expected.json
+++ b/test/resources/templates-to-normalise/exclude-from-pdf-in-summary-section-expected.json
@@ -108,5 +108,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/file-upload-with-object-store-expected.json
+++ b/test/resources/templates-to-normalise/file-upload-with-object-store-expected.json
@@ -79,5 +79,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/revealing-choice-include-revealing-choice-expected.json
+++ b/test/resources/templates-to-normalise/revealing-choice-include-revealing-choice-expected.json
@@ -110,5 +110,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/revealing-choice-with-yesno-choice-expected.json
+++ b/test/resources/templates-to-normalise/revealing-choice-with-yesno-choice-expected.json
@@ -102,5 +102,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/resources/templates-to-normalise/tasklist-choice-expected.json
+++ b/test/resources/templates-to-normalise/tasklist-choice-expected.json
@@ -89,5 +89,6 @@
   "parentFormSubmissionRefs": [],
   "accessiblePdf": false,
   "downloadPreviousSubmissionPdf": true,
-  "displayAccountHeader": false
+  "displayAccountHeader": false,
+  "serviceNavigationComponent": false
 }

--- a/test/uk/gov/hmrc/gform/core/parsers/ValueParserSpec.scala
+++ b/test/uk/gov/hmrc/gform/core/parsers/ValueParserSpec.scala
@@ -529,7 +529,8 @@ class ValueParserSpec extends Spec with TableDrivenPropertyChecks {
     false,
     None,
     true,
-    None
+    None,
+    false
   )
 
   val yourDetailsSection = Section.NonRepeatingPage(

--- a/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
@@ -556,7 +556,8 @@ trait ExampleFormTemplate {
     false,
     Some(serviceStartPageUrl),
     true,
-    None
+    None,
+    false
   )
 }
 

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplateJSONSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplateJSONSpec.scala
@@ -60,6 +60,7 @@ class FormTemplateJSONSpec extends Spec with TableDrivenPropertyChecks {
                                              |  "accessiblePdf":false,
                                              |  "downloadPreviousSubmissionPdf":true,
                                              |  "displayAccountHeader":false,
+                                             |  "serviceNavigationComponent": false,
                                              |  "parentFormSubmissionRefs": [],
                                              |  "summarySection": $summarySection,
                                              |  "allowedFileTypes": [
@@ -186,6 +187,7 @@ class FormTemplateJSONSpec extends Spec with TableDrivenPropertyChecks {
                                              |  "accessiblePdf":false,
                                              |  "downloadPreviousSubmissionPdf":true,
                                              |  "displayAccountHeader":false,
+                                             |  "serviceNavigationComponent": false,
                                              |  "parentFormSubmissionRefs": [
                                              |    "123",
                                              |    "456"
@@ -330,6 +332,7 @@ class FormTemplateJSONSpec extends Spec with TableDrivenPropertyChecks {
                                  |  "accessiblePdf":false,
                                  |  "downloadPreviousSubmissionPdf":true,
                                  |  "displayAccountHeader":false,
+                                 |  "serviceNavigationComponent": false,
                                  |  "testText": "hello",
                                  |  "testJsonArr": [
                                  |    "en",
@@ -479,6 +482,7 @@ class FormTemplateJSONSpec extends Spec with TableDrivenPropertyChecks {
                                                                    |  "accessiblePdf":false,
                                                                    |  "downloadPreviousSubmissionPdf":true,
                                                                    |  "displayAccountHeader":false,
+                                                                   |  "serviceNavigationComponent": false,
                                                                    |  "testText": "hello",
                                                                    |  "testJsonArr": [
                                                                    |    "en",

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplateJSONSuite.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplateJSONSuite.scala
@@ -133,6 +133,7 @@ class FormTemplateJSONSuite extends FunSuite with JsResultMatcher with Matchers 
              |  "accessiblePdf":false,
              |  "downloadPreviousSubmissionPdf":true,
              |  "displayAccountHeader":false,
+             |  "serviceNavigationComponent": false,
              |  "parentFormSubmissionRefs": []
              |}""".stripMargin
         )
@@ -275,6 +276,7 @@ class FormTemplateJSONSuite extends FunSuite with JsResultMatcher with Matchers 
              |  "accessiblePdf":false,
              |  "downloadPreviousSubmissionPdf":true,
              |  "displayAccountHeader":false,
+             |  "serviceNavigationComponent": false,
              |  "parentFormSubmissionRefs": []
              |}""".stripMargin
         )

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/FormTemplateGen.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/FormTemplateGen.scala
@@ -161,7 +161,8 @@ trait FormTemplateGen {
       false,
       serviceStartPageUrl,
       true,
-      None
+      None,
+      false
     )
 }
 


### PR DESCRIPTION
add option to use govuk service navigation component for displaying the form title