### PR TITLE
GFORMS-4499: Different CMA/IF APIs require different auth tokens

### DIFF
--- a/app/uk/gov/hmrc/gform/config/ConfigModule.scala
+++ b/app/uk/gov/hmrc/gform/config/ConfigModule.scala
@@ -143,6 +143,11 @@ class ConfigModule(
     private def authToken(destinationServiceKey: String): Option[Authorization] =
       getString(destinationServiceKey, "authorization-token").map(a => Authorization(s"Bearer $a"))
 
+    private def authTokenMap(destinationServiceKey: String): Map[AuthorizationName, Authorization] =
+      asStringStringMap(s"${qualifiedDestinationServiceKey(destinationServiceKey)}.authorization-token")
+        .getOrElse(Map[String, String]())
+        .map { case (key, value) => AuthorizationName(key) -> Authorization(s"Bearer $value") }
+
     private val enableAuditKey = "enable-audit"
     def auditDestinations: Boolean = getConfBool(s"destination-services.$enableAuditKey", false)
 
@@ -164,6 +169,7 @@ class ConfigModule(
             name,
             baseUrl(destinationServiceKey) + basePath(destinationServiceKey),
             authToken(destinationServiceKey),
+            authTokenMap(destinationServiceKey),
             httpHeaders(destinationServiceKey)
           )
           Some((name, configuration))

--- a/app/uk/gov/hmrc/gform/config/ConfigModule.scala
+++ b/app/uk/gov/hmrc/gform/config/ConfigModule.scala
@@ -144,7 +144,7 @@ class ConfigModule(
       getString(destinationServiceKey, "authorization-token").map(a => Authorization(s"Bearer $a"))
 
     private def authTokenMap(destinationServiceKey: String): Map[AuthorizationName, Authorization] =
-      asStringStringMap(s"${qualifiedDestinationServiceKey(destinationServiceKey)}.authorization-token")
+      asStringStringMap(s"${qualifiedDestinationServiceKey(destinationServiceKey)}.authorization-token-map")
         .getOrElse(Map[String, String]())
         .map { case (key, value) => AuthorizationName(key) -> Authorization(s"Bearer $value") }
 

--- a/app/uk/gov/hmrc/gform/config/ProfileConfiguration.scala
+++ b/app/uk/gov/hmrc/gform/config/ProfileConfiguration.scala
@@ -16,12 +16,21 @@
 
 package uk.gov.hmrc.gform.config
 
+import play.api.libs.json.{ Format, Json }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.ProfileName
 import uk.gov.hmrc.http.Authorization
+
+case class AuthorizationName(value: String)
+object AuthorizationName {
+  implicit val format: Format[AuthorizationName] = Json.format
+}
 
 case class ProfileConfiguration(
   name: ProfileName,
   baseUrl: String,
-  authorization: Option[Authorization],
+  authorization: Option[
+    Authorization
+  ], //If destination "credential" option is not set, defaults to this value. Otherwise, will use authorizationMap.
+  authorizationMap: Map[AuthorizationName, Authorization],
   httpHeaders: Map[String, String]
 )

--- a/app/uk/gov/hmrc/gform/formtemplate/DestinationsValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/DestinationsValidator.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.gform.formtemplate
 import cats.Monoid
 import cats.implicits._
 import cats.data.NonEmptyList
-import uk.gov.hmrc.gform.config.NRSConnectorConfig
+import uk.gov.hmrc.gform.config.{ AuthorizationName, ConfigModule, NRSConnectorConfig, ProfileConfiguration }
 import uk.gov.hmrc.gform.core.ValidationResult.{ BooleanToValidationResultSyntax, validationResultMonoid }
 import uk.gov.hmrc.gform.core.{ Invalid, Valid, ValidationResult }
 import uk.gov.hmrc.gform.nrs.{ BusinessId, NRSConnector }
@@ -251,4 +251,38 @@ object DestinationsValidator {
         }.combineAll
       case _ => Valid
     }
+
+  def validateDestinationCredentials(destinations: Destinations, configModule: ConfigModule): ValidationResult = {
+    def check(
+      credential: Option[AuthorizationName],
+      profileConfig: ProfileConfiguration,
+      destinationId: DestinationId
+    ): ValidationResult =
+      credential
+        .map { credential =>
+          val credentialExists = profileConfig.authorizationMap.keys.exists(_ == credential)
+          if (credentialExists) Valid
+          else Invalid(s"""Destination: ${destinationId.id} contain non existent credential "${credential.value}" """)
+        }
+        .getOrElse(Valid)
+    destinations match {
+      case Destinations.DestinationList(destinations, _, _) =>
+        destinations.map {
+          case destination: Destination.AsyncHandlebarsHttpApi =>
+            check(
+              destination.credential,
+              configModule.DestinationsServicesConfig()(destination.profile),
+              destination.id
+            )
+          case destination: Destination.HandlebarsHttpApi =>
+            check(
+              destination.credential,
+              configModule.DestinationsServicesConfig()(destination.profile),
+              destination.id
+            )
+          case _ => Valid
+        }.combineAll
+      case _ => Valid
+    }
+  }
 }

--- a/app/uk/gov/hmrc/gform/formtemplate/DestinationsValidator.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/DestinationsValidator.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.gform.formtemplate
 import cats.Monoid
 import cats.implicits._
 import cats.data.NonEmptyList
-import uk.gov.hmrc.gform.config.{ AuthorizationName, ConfigModule, NRSConnectorConfig, ProfileConfiguration }
+import uk.gov.hmrc.gform.config.{ AuthorizationName, NRSConnectorConfig, ProfileConfiguration }
 import uk.gov.hmrc.gform.core.ValidationResult.{ BooleanToValidationResultSyntax, validationResultMonoid }
 import uk.gov.hmrc.gform.core.{ Invalid, Valid, ValidationResult }
 import uk.gov.hmrc.gform.nrs.{ BusinessId, NRSConnector }
@@ -27,7 +27,7 @@ import uk.gov.hmrc.gform.sharedmodel.HandlebarsSchemaId
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.Destination.NRSOrchestrator
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.DestinationIncludeIf.{ HandlebarValue, IncludeIfValue }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormComponent, FormComponentId, FormTemplateId, IsGroup }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ Destination, DestinationId, Destinations }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ Destination, DestinationId, Destinations, ProfileName }
 
 object DestinationsValidator {
   def someDestinationIdsAreUsedMoreThanOnce(duplicates: Set[DestinationId]) =
@@ -252,7 +252,10 @@ object DestinationsValidator {
       case _ => Valid
     }
 
-  def validateDestinationCredentials(destinations: Destinations, configModule: ConfigModule): ValidationResult = {
+  def validateDestinationCredentials(
+    destinations: Destinations,
+    profileMap: Map[ProfileName, ProfileConfiguration]
+  ): ValidationResult = {
     def check(
       credential: Option[AuthorizationName],
       profileConfig: ProfileConfiguration,
@@ -271,13 +274,13 @@ object DestinationsValidator {
           case destination: Destination.AsyncHandlebarsHttpApi =>
             check(
               destination.credential,
-              configModule.DestinationsServicesConfig()(destination.profile),
+              profileMap(destination.profile),
               destination.id
             )
           case destination: Destination.HandlebarsHttpApi =>
             check(
               destination.credential,
-              configModule.DestinationsServicesConfig()(destination.profile),
+              profileMap(destination.profile),
               destination.id
             )
           case _ => Valid

--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateModule.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateModule.scala
@@ -94,9 +94,8 @@ class FormTemplateModule(
       formRedirectRepo,
       foptHandlebarsPayloadService,
       foptHandlebarsSchemaService,
-      configModule.appConfig,
-      configModule.nrsConfig,
-      gformFrontendModule.gformFrontendConnector
+      gformFrontendModule.gformFrontendConnector,
+      configModule
     )
   val formRedirectService: FormRedirectService =
     new FormRedirectService(formRedirectRepo)

--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateService.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.gform.formtemplate
 import cats.implicits._
 import org.slf4j.LoggerFactory
 import play.api.libs.json.JsObject
-import uk.gov.hmrc.gform.config.{ AppConfig, NRSConnectorConfig }
+import uk.gov.hmrc.gform.config.ConfigModule
 import uk.gov.hmrc.gform.core.{ FOpt, _ }
 import uk.gov.hmrc.gform.exceptions.UnexpectedState
 import uk.gov.hmrc.gform.formredirect.FormRedirect
@@ -46,9 +46,8 @@ class FormTemplateService(
   formRedirectRepo: Repo[FormRedirect],
   handlebarsTemplateAlgebra: HandlebarsTemplateAlgebra[FOpt],
   handlebarsSchemaAlgebra: HandlebarsSchemaAlgebra[FOpt],
-  appConfig: AppConfig,
-  nrsConnectorConfig: NRSConnectorConfig,
-  gformFrontendConnector: GformFrontendConnector
+  gformFrontendConnector: GformFrontendConnector,
+  configModule: ConfigModule
 )(implicit
   ec: ExecutionContext
 ) extends Verifier with Rewriter with SubstituteExpressions with SubstituteBooleanExprs
@@ -145,10 +144,11 @@ class FormTemplateService(
         handlebarsSchemaIds <- handlebarsSchemaAlgebra.getAllIds
         _ <- verify(
                formTemplateConfirmationsUpdated,
-               appConfig,
-               nrsConnectorConfig,
+               configModule.appConfig,
+               configModule.nrsConfig,
                handlebarsSchemaIds,
-               booleanExpressionsContextSubstituted
+               booleanExpressionsContextSubstituted,
+               configModule
              )(expressionsContext)
         formTemplateUpdated <- rewrite(formTemplateConfirmationsUpdated)
       } yield formTemplateUpdated

--- a/app/uk/gov/hmrc/gform/formtemplate/FormTemplateService.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/FormTemplateService.scala
@@ -148,7 +148,7 @@ class FormTemplateService(
                configModule.nrsConfig,
                handlebarsSchemaIds,
                booleanExpressionsContextSubstituted,
-               configModule
+               configModule.DestinationsServicesConfig()
              )(expressionsContext)
         formTemplateUpdated <- rewrite(formTemplateConfirmationsUpdated)
       } yield formTemplateUpdated

--- a/app/uk/gov/hmrc/gform/formtemplate/Rewriter.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/Rewriter.scala
@@ -114,8 +114,8 @@ trait Rewriter {
           section => section.includeIf.fold(List.empty[IncludeIf])(List(_)) ++ section.fields.flatMap(_.includeIf)
         ) ++ dl.destinations.toList.collect {
           case HmrcDms(_, _, _, _, _, _, IncludeIfValue(includeIf), _, _, _, _, _, _, _, _, _, _, _, _) => includeIf
-          case HandlebarsHttpApi(_, _, _, _, _, _, IncludeIfValue(includeIf), _, _, _)                  => includeIf
-          case AsyncHandlebarsHttpApi(_, _, _, _, _, _, IncludeIfValue(includeIf), _, _)                => includeIf
+          case HandlebarsHttpApi(_, _, _, _, _, _, IncludeIfValue(includeIf), _, _, _, _)               => includeIf
+          case AsyncHandlebarsHttpApi(_, _, _, _, _, _, IncludeIfValue(includeIf), _, _, _)             => includeIf
           case StateTransition(_, _, IncludeIfValue(includeIf), _)                                      => includeIf
           case SubmissionConsolidator(_, _, _, _, IncludeIfValue(includeIf), _)                         => includeIf
           case Email(_, _, IncludeIfValue(includeIf), _, _, _)                                          => includeIf

--- a/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
@@ -16,11 +16,12 @@
 
 package uk.gov.hmrc.gform.formtemplate
 
-import uk.gov.hmrc.gform.config.{ AppConfig, ConfigModule, NRSConnectorConfig }
+import uk.gov.hmrc.gform.config.{ AppConfig, NRSConnectorConfig, ProfileConfiguration }
 import uk.gov.hmrc.gform.core.{ FOpt, fromOptA }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 import cats.implicits._
 import uk.gov.hmrc.gform.sharedmodel.HandlebarsSchemaId
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.ProfileName
 
 import scala.concurrent.ExecutionContext
 
@@ -31,7 +32,7 @@ trait Verifier {
     nrsConnectorConfig: NRSConnectorConfig,
     handlebarsSchemaIds: List[HandlebarsSchemaId],
     booleanExpressionsContextSubstituted: BooleanExprSubstitutions,
-    configModule: ConfigModule
+    profileMap: Map[ProfileName, ProfileConfiguration]
   )(expressionsContext: ExprSubstitutions)(implicit ec: ExecutionContext): FOpt[Unit] = {
 
     val sections = formTemplate.formKind.allSections
@@ -144,7 +145,7 @@ trait Verifier {
       _ <- fromOptA(populateAtlValidator.validate(pages).toEither)
       _ <- fromOptA(populateAtlValidator.formDataRetrieveDoesNotContainPopulateAtl().toEither)
       _ <- fromOptA(
-             DestinationsValidator.validateDestinationCredentials(formTemplate.destinations, configModule).toEither
+             DestinationsValidator.validateDestinationCredentials(formTemplate.destinations, profileMap).toEither
            )
     } yield ()
 

--- a/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
+++ b/app/uk/gov/hmrc/gform/formtemplate/Verifier.scala
@@ -16,11 +16,10 @@
 
 package uk.gov.hmrc.gform.formtemplate
 
-import uk.gov.hmrc.gform.config.NRSConnectorConfig
+import uk.gov.hmrc.gform.config.{ AppConfig, ConfigModule, NRSConnectorConfig }
 import uk.gov.hmrc.gform.core.{ FOpt, fromOptA }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 import cats.implicits._
-import uk.gov.hmrc.gform.config.AppConfig
 import uk.gov.hmrc.gform.sharedmodel.HandlebarsSchemaId
 
 import scala.concurrent.ExecutionContext
@@ -31,7 +30,8 @@ trait Verifier {
     appConfig: AppConfig,
     nrsConnectorConfig: NRSConnectorConfig,
     handlebarsSchemaIds: List[HandlebarsSchemaId],
-    booleanExpressionsContextSubstituted: BooleanExprSubstitutions
+    booleanExpressionsContextSubstituted: BooleanExprSubstitutions,
+    configModule: ConfigModule
   )(expressionsContext: ExprSubstitutions)(implicit ec: ExecutionContext): FOpt[Unit] = {
 
     val sections = formTemplate.formKind.allSections
@@ -143,6 +143,9 @@ trait Verifier {
       _ <- fromOptA(AcknowledgementValidator.validateNoPIITitle(formTemplate, allExpressions).toEither)
       _ <- fromOptA(populateAtlValidator.validate(pages).toEither)
       _ <- fromOptA(populateAtlValidator.formDataRetrieveDoesNotContainPopulateAtl().toEither)
+      _ <- fromOptA(
+             DestinationsValidator.validateDestinationCredentials(formTemplate.destinations, configModule).toEither
+           )
     } yield ()
 
   }

--- a/app/uk/gov/hmrc/gform/integrationFramework/IfController.scala
+++ b/app/uk/gov/hmrc/gform/integrationFramework/IfController.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.gform.integrationFramework
 
 import org.slf4j.LoggerFactory
-import play.api.libs.json.{ Format, JsError, JsObject, JsString, JsSuccess, Json }
+import play.api.libs.json._
 import play.api.mvc._
-import uk.gov.hmrc.gform.config.ConfigModule
+import uk.gov.hmrc.gform.config.{ AuthorizationName, ConfigModule }
 import uk.gov.hmrc.gform.controllers.BaseController
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.ProfileName
 import uk.gov.hmrc.gform.wshttp.WSHttpModule
@@ -51,18 +51,26 @@ class IfController(configModule: ConfigModule, wSHttpModule: WSHttpModule, cc: C
       wSHttpModule.httpClient.post(url"$fullUrl")(hc).setHeader(headers: _*)
   }
 
-  private def ifRequest(path: String, correlationId: String) = {
+  private def ifRequest(path: String, correlationId: String, authorizationName: AuthorizationName) = {
     val profileConfig = configModule.DestinationsServicesConfig()(
       ProfileName("cma")
     ) //TODO: Not sure if it's a good idea to pull config from "cma" profile
     val fullUrl = s"${profileConfig.baseUrl}$path"
 
+    val auth = profileConfig.authorizationMap.getOrElse(
+      authorizationName,
+      throw new RuntimeException(s"""Authorization name: "$authorizationName" is not available for profile "cma" """)
+    )
+
     val headers = Seq(
       "Accept"           -> "application/json",
       "X-Forwarded-Host" -> "MDTP",
       "X-Correlation-Id" -> correlationId,
-      "Date"             -> DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'UTC'").format(ZonedDateTime.now(ZoneOffset.UTC))
-    ) ++ profileConfig.authorization.map(key => "Authorization" -> key.value)
+      "Date" -> DateTimeFormatter
+        .ofPattern("EEE, dd MMM yyyy HH:mm:ss 'UTC'")
+        .format(ZonedDateTime.now(ZoneOffset.UTC)),
+      "Authorization" -> auth.value
+    )
 
     new IfRequest(url"$fullUrl", headers)
   }
@@ -75,7 +83,7 @@ class IfController(configModule: ConfigModule, wSHttpModule: WSHttpModule, cc: C
 
   def manageEmails(eori: String): Action[AnyContent] = Action.async { implicit req =>
     withCorrelationIdHeader(req) { correlationId =>
-      ifRequest(s"/fta/manageemails/v1?eori=$eori", correlationId).get.execute
+      ifRequest(s"/fta/manageemails/v1?eori=$eori", correlationId, AuthorizationName("ifta")).get.execute
         .map { resp =>
           if (resp.status > 299) {
             logger.error(

--- a/app/uk/gov/hmrc/gform/scheduler/asynchandlebars/AsyncHandlebarsWorkItem.scala
+++ b/app/uk/gov/hmrc/gform/scheduler/asynchandlebars/AsyncHandlebarsWorkItem.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.gform.scheduler.asynchandlebars
 
+import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json._
 import uk.gov.hmrc.crypto.{ Crypted, Decrypter, Encrypter, PlainText }
+import uk.gov.hmrc.gform.config.AuthorizationName
 import uk.gov.hmrc.gform.sharedmodel.config.ContentType
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ HttpMethod, ProfileName }
 
@@ -26,7 +28,8 @@ case class AsyncHandlebarsWorkItem(
   uri: String,
   method: HttpMethod,
   contentType: ContentType,
-  payload: String
+  payload: String,
+  credential: Option[AuthorizationName]
 )
 
 object AsyncHandlebarsWorkItem {
@@ -35,13 +38,19 @@ object AsyncHandlebarsWorkItem {
       private val uri = "uri"
       private val method = "method"
       private val payload = "payload"
+      private val credential = "credential"
 
       override def writes(workItem: AsyncHandlebarsWorkItem): JsObject =
         ProfileName.oformat.writes(workItem.profile) ++
           Json.obj(uri -> workItem.uri) ++
           Json.obj(method -> workItem.method) ++
           ContentType.oformat.writes(workItem.contentType) ++
-          Json.obj(payload -> JsString(jsonCrypto.encrypt(PlainText(workItem.payload)).value))
+          Json.obj(payload -> JsString(jsonCrypto.encrypt(PlainText(workItem.payload)).value)) ++
+          workItem.credential
+            .map { credential =>
+              Json.obj(credential.value -> JsString(credential.value))
+            }
+            .getOrElse(Json.obj())
 
       override def reads(json: JsValue): JsResult[AsyncHandlebarsWorkItem] =
         for {
@@ -50,12 +59,20 @@ object AsyncHandlebarsWorkItem {
           method      <- (json \ method).validate[HttpMethod]
           contentType <- ContentType.oformat.reads(json)
           payload     <- (json \ payload).validate[String].map(payload => jsonCrypto.decrypt(Crypted(payload)).value)
+          credential <- (json \ credential)
+                          .validateOpt[String]
+                          .map(payload =>
+                            payload.map { payload =>
+                              AuthorizationName(payload)
+                            }
+                          )
         } yield AsyncHandlebarsWorkItem(
           profile,
           uri,
           method,
           contentType,
-          payload
+          payload,
+          credential
         )
     }
 }

--- a/app/uk/gov/hmrc/gform/scheduler/asynchandlebars/AsyncHandlebarsWorkItem.scala
+++ b/app/uk/gov/hmrc/gform/scheduler/asynchandlebars/AsyncHandlebarsWorkItem.scala
@@ -47,8 +47,8 @@ object AsyncHandlebarsWorkItem {
           ContentType.oformat.writes(workItem.contentType) ++
           Json.obj(payload -> JsString(jsonCrypto.encrypt(PlainText(workItem.payload)).value)) ++
           workItem.credential
-            .map { credential =>
-              Json.obj(credential.value -> JsString(credential.value))
+            .map { workItemCredential =>
+              Json.obj(credential -> JsString(workItemCredential.value))
             }
             .getOrElse(Json.obj())
 

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/Destination.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/Destination.scala
@@ -519,7 +519,7 @@ case class UploadableHandlebarsHttpApiDestination(
   includeIf: DestinationIncludeIf,
   failOnError: Option[Boolean],
   multiRequestPayload: Option[Boolean],
-  credential: Option[AuthorizationName]
+  credential: Option[String]
 ) {
   def toHandlebarsHttpApiDestination: Either[String, Destination.HandlebarsHttpApi] =
     for {
@@ -538,7 +538,7 @@ case class UploadableHandlebarsHttpApiDestination(
         failOnError.getOrElse(true),
         multiRequestPayload.getOrElse(false),
         convertSingleQuotes,
-        credential
+        credential.map(AuthorizationName.apply)
       )
 
   def toAsyncHandlebarsHttpApiDestination: Either[String, Destination.AsyncHandlebarsHttpApi] =
@@ -560,7 +560,7 @@ case class UploadableHandlebarsHttpApiDestination(
         cvii,
         failOnError.getOrElse(true),
         convertSingleQuotes,
-        credential
+        credential.map(AuthorizationName.apply)
       )
 
 }

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/Destination.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/Destination.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 import UploadableConditioning._
 import cats.Eq
 import cats.implicits.catsSyntaxEq
+import uk.gov.hmrc.gform.config.AuthorizationName
 import uk.gov.hmrc.gform.core.parsers.BooleanExprParser
 import uk.gov.hmrc.gform.sharedmodel.form.{ FormId, FormStatus }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.DestinationIncludeIf.{ HandlebarValue, IncludeIfValue }
@@ -166,7 +167,8 @@ object Destination {
     includeIf: DestinationIncludeIf,
     failOnError: Boolean,
     multiRequestPayload: Boolean,
-    convertSingleQuotes: Option[Boolean]
+    convertSingleQuotes: Option[Boolean],
+    credential: Option[AuthorizationName]
   ) extends Destination
 
   case class AsyncHandlebarsHttpApi(
@@ -178,7 +180,8 @@ object Destination {
     payloadType: TemplateType,
     includeIf: DestinationIncludeIf,
     failOnError: Boolean,
-    convertSingleQuotes: Option[Boolean]
+    convertSingleQuotes: Option[Boolean],
+    credential: Option[AuthorizationName]
   ) extends Destination
 
   case class StateTransition(
@@ -257,7 +260,7 @@ object Destination {
   val niRefundClaimApi: String = "niRefundClaimApi"
   val nrsOrchestrator: String = "nrsOrchestrator"
 
-  implicit def format: OFormat[Destination] = {
+  implicit val format: OFormat[Destination] = {
     implicit val personalisationReads =
       JsonUtils.formatMap[NotifierPersonalisationFieldId, FormComponentId](NotifierPersonalisationFieldId(_), _.value)
 
@@ -515,7 +518,8 @@ case class UploadableHandlebarsHttpApiDestination(
   convertSingleQuotes: Option[Boolean],
   includeIf: DestinationIncludeIf,
   failOnError: Option[Boolean],
-  multiRequestPayload: Option[Boolean]
+  multiRequestPayload: Option[Boolean],
+  credential: Option[AuthorizationName]
 ) {
   def toHandlebarsHttpApiDestination: Either[String, Destination.HandlebarsHttpApi] =
     for {
@@ -533,7 +537,8 @@ case class UploadableHandlebarsHttpApiDestination(
         cvii,
         failOnError.getOrElse(true),
         multiRequestPayload.getOrElse(false),
-        convertSingleQuotes
+        convertSingleQuotes,
+        credential
       )
 
   def toAsyncHandlebarsHttpApiDestination: Either[String, Destination.AsyncHandlebarsHttpApi] =
@@ -554,7 +559,8 @@ case class UploadableHandlebarsHttpApiDestination(
         payloadType.getOrElse(TemplateType.JSON),
         cvii,
         failOnError.getOrElse(true),
-        convertSingleQuotes
+        convertSingleQuotes,
+        credential
       )
 
 }

--- a/app/uk/gov/hmrc/gform/submission/destinations/AsyncHttpWorkItemSubmitter.scala
+++ b/app/uk/gov/hmrc/gform/submission/destinations/AsyncHttpWorkItemSubmitter.scala
@@ -90,7 +90,8 @@ class RealAsyncHttpWorkItemSubmitter(
         uri = uri,
         method = destination.method,
         contentType = contentType,
-        payload = payload
+        payload = payload,
+        credential = destination.credential
       )
     )
 

--- a/app/uk/gov/hmrc/gform/submission/handlebars/AsyncHandlebarsApiExecutor.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/AsyncHandlebarsApiExecutor.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.gform.submission.handlebars
 
 import org.slf4j.LoggerFactory
+import uk.gov.hmrc.gform.config.AuthorizationName
 import uk.gov.hmrc.gform.scheduler.TraceableWorkItem
 import uk.gov.hmrc.gform.scheduler.asynchandlebars.AsyncHandlebarsWorkItem
 import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
@@ -33,7 +34,14 @@ trait AsyncHandlebarsApiExecutor[F[_]] {
 }
 
 class RealAsyncHandlebarsApiExecutor(
-  buildRequest: (ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier) => RequestBuilder,
+  buildRequest: (
+    ProfileName,
+    EnvelopeId,
+    String,
+    HttpMethod,
+    HeaderCarrier,
+    Option[AuthorizationName]
+  ) => RequestBuilder,
   workItemHistoryService: WorkItemHistoryAlgebra[Future]
 )(implicit ec: ExecutionContext)
     extends AsyncHandlebarsApiExecutor[Future] {
@@ -47,7 +55,8 @@ class RealAsyncHandlebarsApiExecutor(
       workItem.envelopeId,
       workItem.data.uri,
       workItem.data.method,
-      hc
+      hc,
+      workItem.data.credential
     )
 
     def send(body: String): Future[HttpResponse] =

--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiModule.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.gform.submission.handlebars
 
-import uk.gov.hmrc.gform.config.ConfigModule
+import uk.gov.hmrc.gform.config.{ AuthorizationName, ConfigModule }
 import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ HttpMethod, ProfileName }
 import uk.gov.hmrc.gform.submission.WorkItemHistoryAlgebra
@@ -54,16 +54,27 @@ class HandlebarsHttpApiModule(
     envelopeId: EnvelopeId,
     uri: String,
     method: HttpMethod,
-    hc: HeaderCarrier
+    hc: HeaderCarrier,
+    authorizationName: Option[AuthorizationName]
   ): RequestBuilder = {
     val profileConfig = configModule.DestinationsServicesConfig()(profile)
     val fullUrl = appendUriSegment(profileConfig.baseUrl, uri)
+
+    val auth = authorizationName
+      .map { authName =>
+        profileConfig.authorizationMap
+          .getOrElse(
+            authName,
+            throw new RuntimeException(s"""Authorization name "$authName" not found for profile "$profile" """)
+          )
+      }
+      .orElse(profileConfig.authorization)
 
     val headers: Seq[(String, String)] = hc.extraHeaders ++ profileConfig.httpHeaders.map {
       case (k, checkToken(v)) => k -> getDynamicHeaderValue(v, envelopeId)
       case (k, v)             => k -> v
     }.toSeq ++
-      profileConfig.authorization
+      auth
         .orElse(hc.authorization)
         .map(auth => "Authorization" -> auth.value)
 

--- a/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitter.scala
+++ b/app/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitter.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.gform.submission.handlebars
 
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
+import uk.gov.hmrc.gform.config.AuthorizationName
 import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations._
 import uk.gov.hmrc.gform.submission.destinations._
@@ -38,7 +39,14 @@ trait HandlebarsHttpApiSubmitter {
 }
 
 class RealHandlebarsHttpApiSubmitter(
-  buildRequest: (ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier) => RequestBuilder,
+  buildRequest: (
+    ProfileName,
+    EnvelopeId,
+    String,
+    HttpMethod,
+    HeaderCarrier,
+    Option[AuthorizationName]
+  ) => RequestBuilder,
   handlebarsTemplateProcessor: HandlebarsTemplateProcessor = RealHandlebarsTemplateProcessor
 )(implicit ec: ExecutionContext)
     extends HandlebarsHttpApiSubmitter {
@@ -59,7 +67,8 @@ class RealHandlebarsHttpApiSubmitter(
       FocussedHandlebarsModelTree(modelTree),
       TemplateType.Plain
     )
-    val requestBuilder = buildRequest(destination.profile, envelopeId, uri, destination.method, hc)
+    val requestBuilder =
+      buildRequest(destination.profile, envelopeId, uri, destination.method, hc, destination.credential)
 
     val contentType = destination.payloadType match {
       case TemplateType.JSON  => "application/json"
@@ -129,7 +138,7 @@ class RealHandlebarsHttpApiSubmitter(
 
     destination.method match {
       case HttpMethod.GET =>
-        buildRequest(destination.profile, envelopeId, uri, destination.method, hc)
+        buildRequest(destination.profile, envelopeId, uri, destination.method, hc, destination.credential)
           .execute[HttpResponse]
 
       case HttpMethod.POST =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -283,6 +283,9 @@ microservice {
                 "X-Correlation-Id" = "{envelopeId}"
                 "Date" = "{dateFormat(EEE, dd MMM yyyy HH:mm:ss 'UTC')}"
             }
+            authorization-token {
+                "ifta" = "token"
+            }
         }
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -283,10 +283,6 @@ microservice {
                 "X-Correlation-Id" = "{envelopeId}"
                 "Date" = "{dateFormat(EEE, dd MMM yyyy HH:mm:ss 'UTC')}"
             }
-            authorization-token = "authToken"
-            authorization-token-map {
-                "ifta" = "ifta"
-            }
         }
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -283,8 +283,9 @@ microservice {
                 "X-Correlation-Id" = "{envelopeId}"
                 "Date" = "{dateFormat(EEE, dd MMM yyyy HH:mm:ss 'UTC')}"
             }
-            authorization-token {
-                "ifta" = "token"
+            authorization-token = "authToken"
+            authorization-token-map {
+                "ifta" = "ifta"
             }
         }
     }

--- a/test/uk/gov/hmrc/gform/formtemplate/FormTemplatesControllerRequestHandlerTest.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/FormTemplatesControllerRequestHandlerTest.scala
@@ -505,7 +505,14 @@ class FormTemplatesControllerRequestHandlerTest extends AnyWordSpec with Matcher
     val verifySideEffect: Option[FOpt[Unit]] =
       formTemplate.map(formTemplate =>
         new Verifier {}
-          .verify(formTemplate, appConfig, nrsConfig, List.empty[HandlebarsSchemaId], BooleanExprSubstitutions.empty)(
+          .verify(
+            formTemplate,
+            appConfig,
+            nrsConfig,
+            List.empty[HandlebarsSchemaId],
+            BooleanExprSubstitutions.empty,
+            Map()
+          )(
             ExprSubstitutions.empty
           )
       )

--- a/test/uk/gov/hmrc/gform/formtemplate/VerifierSpec.scala
+++ b/test/uk/gov/hmrc/gform/formtemplate/VerifierSpec.scala
@@ -56,7 +56,8 @@ class VerifierSpec extends AnyWordSpecLike with Matchers with ScalaFutures with 
           appConfig,
           nrsConfig,
           List.empty[HandlebarsSchemaId],
-          BooleanExprSubstitutions.empty
+          BooleanExprSubstitutions.empty,
+          Map()
         )(ExprSubstitutions.empty)
 
       result.value.futureValue shouldBe Left(

--- a/test/uk/gov/hmrc/gform/sharedmodel/FormComponentRejectSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/FormComponentRejectSpec.scala
@@ -92,7 +92,7 @@ class FormComponentRejectSpec extends Spec with TableDrivenPropertyChecks {
       val jsResult = readAsFormTemplate(fileName)
       jsResult match {
         case JsSuccess(formTemplate, _) =>
-          val verificationResult: FOpt[Unit] = new Verifier {}.verify(formTemplate, appConfig, nrsConfig, List.empty[HandlebarsSchemaId], BooleanExprSubstitutions.empty)(ExprSubstitutions.empty)
+          val verificationResult: FOpt[Unit] = new Verifier {}.verify(formTemplate, appConfig, nrsConfig, List.empty[HandlebarsSchemaId], BooleanExprSubstitutions.empty, Map())(ExprSubstitutions.empty)
           verificationResult.value.futureValue shouldBe Left(UnexpectedState(expectedMessage))
         case JsError(errors) => fail("Invalid formTemplate definition: " + errors)
       }
@@ -151,7 +151,8 @@ class FormComponentRejectSpec extends Spec with TableDrivenPropertyChecks {
               appConfig,
               nrsConfig,
               List.empty[HandlebarsSchemaId],
-              BooleanExprSubstitutions.empty
+              BooleanExprSubstitutions.empty,
+              Map()
             )(ExprSubstitutions.empty)
           verificationResult.value.futureValue shouldBe Left(UnexpectedState(expectedMessage))
         case JsError(errors) => fail("Invalid formTemplate definition: " + errors)

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/UploadableDestinationSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/UploadableDestinationSpec.scala
@@ -124,7 +124,8 @@ class UploadableDestinationSpec extends Spec with ScalaCheckDrivenPropertyChecks
       convertSingleQuotes,
       includeIf,
       Some(failOnError),
-      Some(multiRequestPayload)
+      Some(multiRequestPayload),
+      None
     )
   }
 

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/DestinationGen.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/DestinationGen.scala
@@ -122,6 +122,7 @@ trait DestinationGen {
       includeIf,
       failOnError,
       multiRequestPayload,
+      None,
       None
     )
 

--- a/test/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitterSpec.scala
+++ b/test/uk/gov/hmrc/gform/submission/handlebars/HandlebarsHttpApiSubmitterSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate.generators.DestinationGen
 import uk.gov.hmrc.gform.sharedmodel.structuredform.StructuredFormValue
 import uk.gov.hmrc.gform.submission.destinations.{ DestinationSubmissionInfo, DestinationSubmissionInfoGen }
 import uk.gov.hmrc.gform.Spec
+import uk.gov.hmrc.gform.config.AuthorizationName
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpReads, HttpResponse }
 import uk.gov.hmrc.http.client.RequestBuilder
 
@@ -50,7 +51,9 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedUri = "test-uri"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, Option[
+      AuthorizationName
+    ], RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -63,7 +66,7 @@ class HandlebarsHttpApiSubmitterSpec
       .anyNumberOfTimes()
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.GET, hc)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.GET, hc, None)
       .returning(mockRequestBuilder)
       .anyNumberOfTimes()
 
@@ -89,7 +92,9 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedBody = "processed-body"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, Option[
+      AuthorizationName
+    ], RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -105,7 +110,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning(expectedBody)
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc, None)
       .returning(mockRequestBuilder)
 
     (mockRequestBuilder
@@ -137,7 +142,9 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedUri = "test-uri"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, Option[
+      AuthorizationName
+    ], RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -149,7 +156,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning(expectedUri)
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc, None)
       .returning(mockRequestBuilder)
 
     (mockRequestBuilder
@@ -183,7 +190,9 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedBody = "processed-body"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, Option[
+      AuthorizationName
+    ], RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -199,7 +208,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning(expectedBody)
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.PUT, hc)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.PUT, hc, None)
       .returning(mockRequestBuilder)
 
     (mockRequestBuilder
@@ -236,7 +245,9 @@ class HandlebarsHttpApiSubmitterSpec
     val expectedUri = "test-uri"
 
     val mockRequestBuilder = mock[RequestBuilder]
-    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, RequestBuilder]
+    val buildRequest = mockFunction[ProfileName, EnvelopeId, String, HttpMethod, HeaderCarrier, Option[
+      AuthorizationName
+    ], RequestBuilder]
     val handlebarsTemplateProcessor = mock[HandlebarsTemplateProcessor]
     val expectedResponse = mock[HttpResponse]
 
@@ -256,7 +267,7 @@ class HandlebarsHttpApiSubmitterSpec
       .returning("processed2")
 
     buildRequest
-      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc)
+      .expects(destination.profile, EnvelopeId("envId"), expectedUri, HttpMethod.POST, hc, None)
       .returning(mockRequestBuilder)
       .once()
 


### PR DESCRIPTION
Made some changes to ticket spec.

1. Instead of:
`microservice.destination-services.cma.vatc2c.authorization-token`

This:
`microservice.destination-services.cma.authorization-token-map.vatc2c`

2. "microservice.destination-services.cma.authorization-token" value is still available and will be used as a default value if "credential" parameter is not available on the template.