### PR TITLE
GFORMS-4617: Slow queries in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ dist
 /RUNNING_PID
 /.settings
 *.iws
-.metals/metals.lock.db
+.metals/*
 
     

--- a/app/uk/gov/hmrc/gform/ApplicationLoader.scala
+++ b/app/uk/gov/hmrc/gform/ApplicationLoader.scala
@@ -239,18 +239,78 @@ class ApplicationModule(context: Context)
   private val prodCreatedExpiryDays: Int = configModule.appConfig.formExpiryDaysFromCreation
   private val prodSubmittedExpiryHours: Int = configModule.appConfig.submittedFormExpiryHours
   private val formsCacheRepository =
-    createMongoCacheRepository("forms", prodExpiryDays, prodCreatedExpiryDays, prodSubmittedExpiryHours)
+    createMongoCacheRepository(
+      "forms",
+      prodExpiryDays,
+      formsIndexes(prodExpiryDays, prodCreatedExpiryDays, prodSubmittedExpiryHours)
+    )
   private val formMongoCache = new FormMongoCache(
     formsCacheRepository,
     jsonCrypto,
     timeModule.timeProvider
   )
 
+  private def formsAndSnapshotsCommonIndexes(expiryDays: Int, createdExpiryDays: Int, submittedExpiryHours: Int) = {
+    val formExpiry = expiryDays.days.toMillis
+    val createdFormExpiry = createdExpiryDays.days.toMillis
+    val submittedExpiry = submittedExpiryHours.hours.toMillis
+    Seq(
+      IndexModel(
+        ascending("modifiedDetails.createdAt"),
+        IndexOptions()
+          .background(false)
+          .name("createdAtIndex")
+          .expireAfter(createdFormExpiry, TimeUnit.MILLISECONDS)
+      ),
+      IndexModel(
+        ascending("modifiedDetails.lastUpdated"),
+        IndexOptions()
+          .background(false)
+          .name("lastUpdatedIndex")
+          .expireAfter(formExpiry, TimeUnit.MILLISECONDS)
+      ),
+      IndexModel(
+        ascending("submitDetails.createdAt"),
+        IndexOptions()
+          .background(false)
+          .name("submittedIndex")
+          .expireAfter(submittedExpiry, TimeUnit.MILLISECONDS)
+      ),
+      IndexModel(
+        ascending("data.form.formTemplateId"),
+        IndexOptions()
+          .background(false)
+          .name("formTemplateIdIdx")
+      ),
+      IndexModel(
+        compoundIndex(ascending("data.form.status"), ascending("modifiedDetails.lastUpdated")),
+        IndexOptions()
+          .background(false)
+          .name("statusLastUpdatedIdx")
+      )
+    )
+  }
+
+  private def formsIndexes(expiryDays: Int, createdExpiryDays: Int, submittedExpiryHours: Int) =
+    formsAndSnapshotsCommonIndexes(expiryDays, createdExpiryDays, submittedExpiryHours) ++ Seq(
+      IndexModel(
+        ascending("data.form.userId"),
+        IndexOptions()
+          .background(false)
+          .name("userIdIdx")
+      ),
+      IndexModel(
+        ascending("data.form.envelopeId"),
+        IndexOptions()
+          .background(false)
+          .name("envelopeIdIdx")
+      )
+    )
+
   private def createMongoCacheRepository(
     collectionName: String,
     expiryDays: Int,
-    createdExpiryDays: Int,
-    submittedExpiryHours: Int
+    _indexes: Seq[IndexModel]
   ) = new MongoCacheRepository[String](
     mongoModule.mongoComponent,
     collectionName,
@@ -259,59 +319,8 @@ class ApplicationModule(context: Context)
     new CurrentTimestampSupport(),
     SimpleCacheId
   ) {
-    override def ensureIndexes(): Future[Seq[String]] = {
-      val formExpiry = expiryDays.days.toMillis
-      val createdFormExpiry = createdExpiryDays.days.toMillis
-      val submittedExpiry = submittedExpiryHours.hours.toMillis
-      val indexes = Seq(
-        IndexModel(
-          ascending("modifiedDetails.createdAt"),
-          IndexOptions()
-            .background(false)
-            .name("createdAtIndex")
-            .expireAfter(createdFormExpiry, TimeUnit.MILLISECONDS)
-        ),
-        IndexModel(
-          ascending("modifiedDetails.lastUpdated"),
-          IndexOptions()
-            .background(false)
-            .name("lastUpdatedIndex")
-            .expireAfter(formExpiry, TimeUnit.MILLISECONDS)
-        ),
-        IndexModel(
-          ascending("submitDetails.createdAt"),
-          IndexOptions()
-            .background(false)
-            .name("submittedIndex")
-            .expireAfter(submittedExpiry, TimeUnit.MILLISECONDS)
-        ),
-        IndexModel(
-          ascending("data.form.formTemplateId"),
-          IndexOptions()
-            .background(false)
-            .name("formTemplateIdIdx")
-        ),
-        IndexModel(
-          compoundIndex(ascending("data.form.status"), ascending("modifiedDetails.lastUpdated")),
-          IndexOptions()
-            .background(false)
-            .name("statusLastUpdatedIdx")
-        ),
-        IndexModel(
-          ascending("data.form.userId"),
-          IndexOptions()
-            .background(false)
-            .name("userIdIdx")
-        ),
-        IndexModel(
-          ascending("data.form.envelopeId"),
-          IndexOptions()
-            .background(false)
-            .name("envelopeIdIdx")
-        )
-      )
-      MongoUtils.ensureIndexes(this.collection, indexes, true)
-    }
+    override def ensureIndexes(): Future[Seq[String]] =
+      MongoUtils.ensureIndexes(this.collection, _indexes, true)
   }
 
   private val formService: FormService[Future] = createFormService(formMongoCache)
@@ -420,8 +429,11 @@ class ApplicationModule(context: Context)
   private val snapshotsMongoCache = createMongoCacheRepository(
     "snapshots",
     configModule.snapshotExpiryDays,
-    configModule.snapshotCreatedExpiryDays,
-    configModule.snapshotSubmittedExpiryHours
+    formsAndSnapshotsCommonIndexes(
+      configModule.snapshotExpiryDays,
+      configModule.snapshotCreatedExpiryDays,
+      configModule.snapshotSubmittedExpiryHours
+    )
   )
   private val snapshotMongoCache = new SnapshotMongoCache(
     snapshotsMongoCache

--- a/app/uk/gov/hmrc/gform/ApplicationLoader.scala
+++ b/app/uk/gov/hmrc/gform/ApplicationLoader.scala
@@ -294,12 +294,6 @@ class ApplicationModule(context: Context)
   private def formsIndexes(expiryDays: Int, createdExpiryDays: Int, submittedExpiryHours: Int) =
     formsAndSnapshotsCommonIndexes(expiryDays, createdExpiryDays, submittedExpiryHours) ++ Seq(
       IndexModel(
-        ascending("data.form.userId"),
-        IndexOptions()
-          .background(false)
-          .name("userIdIdx")
-      ),
-      IndexModel(
         ascending("data.form.envelopeId"),
         IndexOptions()
           .background(false)

--- a/app/uk/gov/hmrc/gform/ApplicationLoader.scala
+++ b/app/uk/gov/hmrc/gform/ApplicationLoader.scala
@@ -296,6 +296,18 @@ class ApplicationModule(context: Context)
           IndexOptions()
             .background(false)
             .name("statusLastUpdatedIdx")
+        ),
+        IndexModel(
+          ascending("data.form.userId"),
+          IndexOptions()
+            .background(false)
+            .name("userIdIdx")
+        ),
+        IndexModel(
+          ascending("data.form.envelopeId"),
+          IndexOptions()
+            .background(false)
+            .name("envelopeIdIdx")
         )
       )
       MongoUtils.ensureIndexes(this.collection, indexes, true)

--- a/app/uk/gov/hmrc/gform/sdes/SdesModule.scala
+++ b/app/uk/gov/hmrc/gform/sdes/SdesModule.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.gform.sdes
 
 import com.mongodb.client.result.UpdateResult
 import org.bson.types.ObjectId
+import org.mongodb.scala.model.Indexes.{ ascending, compoundIndex, descending }
 import org.mongodb.scala.model.{ IndexModel, IndexOptions, Indexes }
 import uk.gov.hmrc.crypto.{ Decrypter, Encrypter }
 import uk.gov.hmrc.gform.akka.AkkaModule
@@ -84,6 +85,12 @@ class SdesModule(
           IndexOptions()
             .background(false)
             .name("isProcessed")
+        ),
+        IndexModel(
+          compoundIndex(descending("createdAt"), ascending("_id")),
+          IndexOptions()
+            .background(false)
+            .name("createdAtDesc")
         )
       )
     )


### PR DESCRIPTION
This should fix all slow queries that have been issued in the last 30 days.

Added indexes to sdesDestination and forms collections.
The build process of indexes might be resource intensive, should probably be deployed during low traffic time.